### PR TITLE
Create separate flavor for release to exclude LeakCanary

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,7 +32,7 @@ jobs:
         working-directory: noty-android
 
       - name: Build APKs ⚙️🛠
-        run: bash ./gradlew assembleRelease
+        run: bash ./gradlew assemble
         working-directory: noty-android
 
       - name: Create Release ✅
@@ -52,7 +52,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           upload_url: ${{ steps.create_release.outputs.upload_url }}
-          asset_path: noty-android/app/simpleapp/build/outputs/apk/release/simpleapp-release-unsigned.apk
+          asset_path: noty-android/app/simpleapp/build/outputs/apk/stage/debug/simpleapp-stage-debug.apk
           asset_name: noty-android-simple.apk
           asset_content_type: application/apk
           
@@ -62,6 +62,6 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           upload_url: ${{ steps.create_release.outputs.upload_url }}
-          asset_path: noty-android/app/composeapp/build/outputs/apk/release/composeapp-release-unsigned.apk
+          asset_path: noty-android/app/composeapp/build/outputs/apk/debug/composeapp-debug.apk
           asset_name: noty-android-compose.apk
           asset_content_type: application/apk

--- a/noty-android/app/simpleapp/build.gradle
+++ b/noty-android/app/simpleapp/build.gradle
@@ -39,10 +39,19 @@ android {
     }
 
     buildTypes {
+        debug {
+            minifyEnabled false
+        }
         release {
             minifyEnabled false
             proguardFiles getDefaultProguardFile('proguard-android-optimize.txt'), 'proguard-rules.pro'
         }
+    }
+
+    flavorDimensions "default"
+    productFlavors {
+        stage {}
+        dev {}
     }
 
     compileOptions {
@@ -57,6 +66,10 @@ android {
     lintOptions {
         abortOnError false
     }
+}
+
+configurations {
+    devDebugImplementation {}
 }
 
 tasks.withType(org.jetbrains.kotlin.gradle.tasks.KotlinCompile).all {
@@ -125,5 +138,5 @@ dependencies {
     androidTestImplementation "androidx.test.espresso:espresso-core:$espressoVersion"
 
     // Leak Canary
-    debugImplementation "com.squareup.leakcanary:leakcanary-android:$leakCanaryVersion"
+    devDebugImplementation "com.squareup.leakcanary:leakcanary-android:$leakCanaryVersion"
 }


### PR DESCRIPTION
Create separate flavour for release to exclude LeakCanary so that app testers/users won't be disturbed by LeakCanary notifications.