### PR TITLE
Update `composeapp` to use Jetpack Compose v1.0.0

### DIFF
--- a/noty-android/app/composeapp/build.gradle
+++ b/noty-android/app/composeapp/build.gradle
@@ -137,7 +137,7 @@ dependencies {
     implementation "androidx.work:work-runtime-ktx:$workmanagerVersion"
 
     // Lifecycle
-    implementation "androidx.lifecycle:lifecycle-viewmodel-ktx:$lifecycleVersion"
+    implementation "androidx.lifecycle:lifecycle-viewmodel-compose:$lifecycleViewModelComposeVersion"
     implementation "androidx.lifecycle:lifecycle-runtime-ktx:$lifecycleVersion"
 
     // Compose Lifecycle

--- a/noty-android/app/composeapp/src/main/AndroidManifest.xml
+++ b/noty-android/app/composeapp/src/main/AndroidManifest.xml
@@ -31,7 +31,7 @@
         android:supportsRtl="true"
         android:theme="@style/AppTheme">
         <activity
-            android:name=".view.MainActivity"
+            android:name=".ui.MainActivity"
             android:label="@string/app_name"
             android:theme="@style/AppTheme.Splash">
             <intent-filter>

--- a/noty-android/app/composeapp/src/main/java/dev/shreyaspatil/noty/composeapp/component/NoteCard.kt
+++ b/noty-android/app/composeapp/src/main/java/dev/shreyaspatil/noty/composeapp/component/NoteCard.kt
@@ -43,13 +43,13 @@ fun NoteCard(note: Note, onNoteClick: () -> Unit) {
         modifier = Modifier
             .padding(horizontal = 8.dp, vertical = 4.dp)
             .fillMaxWidth()
-            .wrapContentHeight(),
+            .wrapContentHeight()
+            .clickable { onNoteClick() },
         elevation = 0.dp
     ) {
         Column(
             modifier = Modifier
                 .padding(16.dp)
-                .clickable { onNoteClick() }
         ) {
             Text(
                 text = note.title,

--- a/noty-android/app/composeapp/src/main/java/dev/shreyaspatil/noty/composeapp/component/anim/LottieAnimation.kt
+++ b/noty-android/app/composeapp/src/main/java/dev/shreyaspatil/noty/composeapp/component/anim/LottieAnimation.kt
@@ -18,23 +18,27 @@ package dev.shreyaspatil.noty.composeapp.component.anim
 
 import androidx.annotation.RawRes
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.remember
+import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
 import com.airbnb.lottie.compose.LottieAnimation
-import com.airbnb.lottie.compose.LottieAnimationSpec
-import com.airbnb.lottie.compose.rememberLottieAnimationState
+import com.airbnb.lottie.compose.LottieCompositionSpec
+import com.airbnb.lottie.compose.LottieConstants
+import com.airbnb.lottie.compose.animateLottieCompositionAsState
+import com.airbnb.lottie.compose.rememberLottieComposition
 
 @Composable
-fun LottieAnimation(@RawRes resId: Int, modifier: Modifier = Modifier) {
-    val animationSpec = remember { LottieAnimationSpec.RawRes(resId) }
-    val animationState = rememberLottieAnimationState(
-        autoPlay = true,
-        repeatCount = Integer.MAX_VALUE
+fun LottieAnimation(
+    @RawRes resId: Int,
+    modifier: Modifier = Modifier,
+    iterations: Int = LottieConstants.IterateForever,
+    restartOnPlay: Boolean = true
+) {
+    val composition by rememberLottieComposition(LottieCompositionSpec.RawRes(resId))
+    val progress by animateLottieCompositionAsState(
+        composition,
+        iterations = iterations,
+        restartOnPlay = restartOnPlay
     )
 
-    LottieAnimation(
-        animationSpec,
-        animationState = animationState,
-        modifier = modifier
-    )
+    LottieAnimation(composition, progress, modifier = modifier)
 }

--- a/noty-android/app/composeapp/src/main/java/dev/shreyaspatil/noty/composeapp/component/dialog/NotyDialogs.kt
+++ b/noty-android/app/composeapp/src/main/java/dev/shreyaspatil/noty/composeapp/component/dialog/NotyDialogs.kt
@@ -32,7 +32,7 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.window.Dialog
 import dev.shreyaspatil.noty.composeapp.R
 import dev.shreyaspatil.noty.composeapp.component.anim.LottieAnimation
-import dev.shreyaspatil.noty.composeapp.ui.typography
+import dev.shreyaspatil.noty.composeapp.ui.theme.typography
 
 @Composable
 fun LoaderDialog() {

--- a/noty-android/app/composeapp/src/main/java/dev/shreyaspatil/noty/composeapp/navigation/NotyNavigation.kt
+++ b/noty-android/app/composeapp/src/main/java/dev/shreyaspatil/noty/composeapp/navigation/NotyNavigation.kt
@@ -23,14 +23,15 @@ import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
 import androidx.navigation.compose.navArgument
 import androidx.navigation.compose.rememberNavController
-import dev.shreyaspatil.noty.composeapp.view.Screen
-import dev.shreyaspatil.noty.composeapp.view.screen.AboutScreen
-import dev.shreyaspatil.noty.composeapp.view.screen.AddNoteScreen
+import dev.shreyaspatil.noty.composeapp.ui.Screen
+import dev.shreyaspatil.noty.composeapp.ui.screens.AboutScreen
+import dev.shreyaspatil.noty.composeapp.ui.screens.AddNoteScreen
+import dev.shreyaspatil.noty.composeapp.ui.screens.NoteDetailsScreen
+import dev.shreyaspatil.noty.composeapp.ui.screens.NotesScreen
+import dev.shreyaspatil.noty.composeapp.ui.screens.SignUpScreen
+import dev.shreyaspatil.noty.composeapp.utils.assistedViewModel
 import dev.shreyaspatil.noty.composeapp.view.screen.LoginScreen
-import dev.shreyaspatil.noty.composeapp.view.screen.NoteDetailsScreen
-import dev.shreyaspatil.noty.composeapp.view.screen.NotesScreen
-import dev.shreyaspatil.noty.composeapp.view.screen.SignUpScreen
-import dev.shreyaspatil.noty.composeapp.view.screen.noteDetailViewModel
+import dev.shreyaspatil.noty.view.viewmodel.NoteDetailViewModel
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.InternalCoroutinesApi
 
@@ -61,9 +62,10 @@ fun NotyNavigation(toggleTheme: () -> Unit) {
                 navArgument(Screen.NotesDetail.ARG_NOTE_ID) { type = NavType.StringType }
             )
         ) {
-            val noteId = it.arguments?.getString(Screen.NotesDetail.ARG_NOTE_ID)
-                ?: throw IllegalStateException("'noteId' shouldn't be null")
-            NoteDetailsScreen(navController, noteDetailViewModel(noteId))
+            val noteId = requireNotNull(it.arguments?.getString(Screen.NotesDetail.ARG_NOTE_ID))
+            NoteDetailsScreen(navController, assistedViewModel {
+                NoteDetailViewModel.provideFactory(noteDetailViewModelFactory(), noteId)
+            })
         }
         composable(Screen.About.route) {
             AboutScreen(navController = navController)

--- a/noty-android/app/composeapp/src/main/java/dev/shreyaspatil/noty/composeapp/navigation/NotyNavigation.kt
+++ b/noty-android/app/composeapp/src/main/java/dev/shreyaspatil/noty/composeapp/navigation/NotyNavigation.kt
@@ -63,9 +63,12 @@ fun NotyNavigation(toggleTheme: () -> Unit) {
             )
         ) {
             val noteId = requireNotNull(it.arguments?.getString(Screen.NotesDetail.ARG_NOTE_ID))
-            NoteDetailsScreen(navController, assistedViewModel {
-                NoteDetailViewModel.provideFactory(noteDetailViewModelFactory(), noteId)
-            })
+            NoteDetailsScreen(
+                navController,
+                assistedViewModel {
+                    NoteDetailViewModel.provideFactory(noteDetailViewModelFactory(), noteId)
+                }
+            )
         }
         composable(Screen.About.route) {
             AboutScreen(navController = navController)

--- a/noty-android/app/composeapp/src/main/java/dev/shreyaspatil/noty/composeapp/ui/MainActivity.kt
+++ b/noty-android/app/composeapp/src/main/java/dev/shreyaspatil/noty/composeapp/ui/MainActivity.kt
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package dev.shreyaspatil.noty.composeapp.view
+package dev.shreyaspatil.noty.composeapp.ui
 
 import android.os.Bundle
 import androidx.activity.compose.setContent
@@ -34,7 +34,7 @@ import dagger.hilt.android.AndroidEntryPoint
 import dagger.hilt.android.components.ActivityComponent
 import dev.shreyaspatil.noty.composeapp.R
 import dev.shreyaspatil.noty.composeapp.navigation.NotyNavigation
-import dev.shreyaspatil.noty.composeapp.ui.NotyTheme
+import dev.shreyaspatil.noty.composeapp.ui.theme.NotyTheme
 import dev.shreyaspatil.noty.core.preference.PreferenceManager
 import dev.shreyaspatil.noty.view.viewmodel.NoteDetailViewModel
 import kotlinx.coroutines.ExperimentalCoroutinesApi

--- a/noty-android/app/composeapp/src/main/java/dev/shreyaspatil/noty/composeapp/ui/Screen.kt
+++ b/noty-android/app/composeapp/src/main/java/dev/shreyaspatil/noty/composeapp/ui/Screen.kt
@@ -16,19 +16,16 @@
 
 package dev.shreyaspatil.noty.composeapp.ui
 
-import androidx.compose.ui.graphics.Color
+sealed class Screen(val route: String, val name: String) {
+    object SignUp : Screen("signup", "Sign Up")
+    object Login : Screen("login", "Login")
+    object Notes : Screen("notes", "Notes")
+    object NotesDetail : Screen("note/{noteId}", "Note details") {
+        fun route(noteId: String) = "note/$noteId"
 
-// primary color
-val primary = Color(0xFF7885FF)
+        const val ARG_NOTE_ID: String = "noteId"
+    }
 
-// for bg
-val bgDay = Color(0xfff3f7f9)
-val bgNight = Color(0xff121212)
-
-// for card colors
-val day = Color(0xffffffff)
-val night = Color(0xff1A191E)
-
-// for text colors
-val black = Color(0xff000000)
-val white = Color(0xffffffff)
+    object AddNote : Screen("note/new", "New note")
+    object About : Screen("about", "About")
+}

--- a/noty-android/app/composeapp/src/main/java/dev/shreyaspatil/noty/composeapp/ui/screens/AboutScreen.kt
+++ b/noty-android/app/composeapp/src/main/java/dev/shreyaspatil/noty/composeapp/ui/screens/AboutScreen.kt
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package dev.shreyaspatil.noty.composeapp.view.screen
+package dev.shreyaspatil.noty.composeapp.ui.screens
 
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.clickable

--- a/noty-android/app/composeapp/src/main/java/dev/shreyaspatil/noty/composeapp/ui/screens/AddNotesScreen.kt
+++ b/noty-android/app/composeapp/src/main/java/dev/shreyaspatil/noty/composeapp/ui/screens/AddNotesScreen.kt
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package dev.shreyaspatil.noty.composeapp.view.screen
+package dev.shreyaspatil.noty.composeapp.ui.screens
 
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.fillMaxHeight

--- a/noty-android/app/composeapp/src/main/java/dev/shreyaspatil/noty/composeapp/ui/screens/NoteDetailsScreen.kt
+++ b/noty-android/app/composeapp/src/main/java/dev/shreyaspatil/noty/composeapp/ui/screens/NoteDetailsScreen.kt
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package dev.shreyaspatil.noty.composeapp.view.screen
+package dev.shreyaspatil.noty.composeapp.ui.screens
 
 import android.app.Activity
 import android.content.Intent
@@ -47,17 +47,13 @@ import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.core.app.ShareCompat
-import androidx.lifecycle.viewmodel.compose.viewModel
 import androidx.navigation.NavHostController
-import dagger.hilt.android.EntryPointAccessors
 import dev.shreyaspatil.noty.composeapp.R
 import dev.shreyaspatil.noty.composeapp.component.action.DeleteAction
 import dev.shreyaspatil.noty.composeapp.component.action.ShareAction
 import dev.shreyaspatil.noty.composeapp.component.dialog.FailureDialog
 import dev.shreyaspatil.noty.composeapp.component.dialog.LoaderDialog
 import dev.shreyaspatil.noty.composeapp.utils.ShowToast
-import dev.shreyaspatil.noty.composeapp.view.MainActivity
-import dev.shreyaspatil.noty.composeapp.view.Screen
 import dev.shreyaspatil.noty.core.view.ViewState
 import dev.shreyaspatil.noty.utils.validator.NoteValidator
 import dev.shreyaspatil.noty.view.viewmodel.NoteDetailViewModel
@@ -99,7 +95,7 @@ fun NoteDetailsScreen(
                         IconButton(
                             modifier = Modifier.padding(12.dp, 0.dp, 0.dp, 0.dp),
                             onClick = {
-                                navController.navigate(Screen.Notes.route)
+                                navController.navigateUp()
                             }
                         ) {
                             Icon(
@@ -214,14 +210,3 @@ fun shareNote(activity: Activity, title: String, note: String) {
     activity.startActivity(Intent.createChooser(intent, null))
 }
 
-@InternalCoroutinesApi
-@ExperimentalCoroutinesApi
-@Composable
-fun noteDetailViewModel(noteId: String): NoteDetailViewModel {
-    val factory = EntryPointAccessors.fromActivity(
-        LocalContext.current as Activity,
-        MainActivity.ViewModelFactoryProvider::class.java
-    ).noteDetailViewModelFactory()
-
-    return viewModel(factory = NoteDetailViewModel.provideFactory(factory, noteId))
-}

--- a/noty-android/app/composeapp/src/main/java/dev/shreyaspatil/noty/composeapp/ui/screens/NoteDetailsScreen.kt
+++ b/noty-android/app/composeapp/src/main/java/dev/shreyaspatil/noty/composeapp/ui/screens/NoteDetailsScreen.kt
@@ -209,4 +209,3 @@ fun shareNote(activity: Activity, title: String, note: String) {
 
     activity.startActivity(Intent.createChooser(intent, null))
 }
-

--- a/noty-android/app/composeapp/src/main/java/dev/shreyaspatil/noty/composeapp/ui/screens/NotesScreen.kt
+++ b/noty-android/app/composeapp/src/main/java/dev/shreyaspatil/noty/composeapp/ui/screens/NotesScreen.kt
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package dev.shreyaspatil.noty.composeapp.view.screen
+package dev.shreyaspatil.noty.composeapp.ui.screens
 
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.material.FloatingActionButton
@@ -40,8 +40,7 @@ import dev.shreyaspatil.noty.composeapp.component.action.LogoutAction
 import dev.shreyaspatil.noty.composeapp.component.action.ThemeSwitchAction
 import dev.shreyaspatil.noty.composeapp.component.dialog.FailureDialog
 import dev.shreyaspatil.noty.composeapp.component.dialog.LoaderDialog
-import dev.shreyaspatil.noty.composeapp.navigation.NOTY_NAV_HOST_ROUTE
-import dev.shreyaspatil.noty.composeapp.view.Screen
+import dev.shreyaspatil.noty.composeapp.ui.Screen
 import dev.shreyaspatil.noty.core.model.Note
 import dev.shreyaspatil.noty.core.view.ViewState
 import dev.shreyaspatil.noty.view.viewmodel.NotesViewModel
@@ -129,9 +128,7 @@ private fun navigateToLogin(navController: NavHostController) {
     navController.navigate(
         Screen.Login.route,
         builder = {
-            popUpTo(NOTY_NAV_HOST_ROUTE) {
-                inclusive = true
-            }
+            launchSingleTop = true
         }
     )
 }

--- a/noty-android/app/composeapp/src/main/java/dev/shreyaspatil/noty/composeapp/ui/screens/SignUpScreen.kt
+++ b/noty-android/app/composeapp/src/main/java/dev/shreyaspatil/noty/composeapp/ui/screens/SignUpScreen.kt
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package dev.shreyaspatil.noty.composeapp.view.screen
+package dev.shreyaspatil.noty.composeapp.ui.screens
 
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
@@ -51,8 +51,8 @@ import androidx.navigation.NavHostController
 import dev.shreyaspatil.noty.composeapp.component.dialog.FailureDialog
 import dev.shreyaspatil.noty.composeapp.component.dialog.LoaderDialog
 import dev.shreyaspatil.noty.composeapp.navigation.NOTY_NAV_HOST_ROUTE
-import dev.shreyaspatil.noty.composeapp.ui.typography
-import dev.shreyaspatil.noty.composeapp.view.Screen
+import dev.shreyaspatil.noty.composeapp.ui.Screen
+import dev.shreyaspatil.noty.composeapp.ui.theme.typography
 import dev.shreyaspatil.noty.core.view.ViewState
 import dev.shreyaspatil.noty.utils.validator.AuthValidator
 import dev.shreyaspatil.noty.view.viewmodel.RegisterViewModel

--- a/noty-android/app/composeapp/src/main/java/dev/shreyaspatil/noty/composeapp/ui/theme/Color.kt
+++ b/noty-android/app/composeapp/src/main/java/dev/shreyaspatil/noty/composeapp/ui/theme/Color.kt
@@ -14,14 +14,21 @@
  * limitations under the License.
  */
 
-package dev.shreyaspatil.noty.composeapp.ui
+package dev.shreyaspatil.noty.composeapp.ui.theme
 
-import androidx.compose.foundation.shape.RoundedCornerShape
-import androidx.compose.material.Shapes
-import androidx.compose.ui.unit.dp
+import androidx.compose.ui.graphics.Color
 
-val shapes = Shapes(
-    small = RoundedCornerShape(4.dp),
-    medium = RoundedCornerShape(4.dp),
-    large = RoundedCornerShape(0.dp)
-)
+// primary color
+val primary = Color(0xFF7885FF)
+
+// for bg
+val bgDay = Color(0xfff3f7f9)
+val bgNight = Color(0xff121212)
+
+// for card colors
+val day = Color(0xffffffff)
+val night = Color(0xff1A191E)
+
+// for text colors
+val black = Color(0xff000000)
+val white = Color(0xffffffff)

--- a/noty-android/app/composeapp/src/main/java/dev/shreyaspatil/noty/composeapp/ui/theme/Shape.kt
+++ b/noty-android/app/composeapp/src/main/java/dev/shreyaspatil/noty/composeapp/ui/theme/Shape.kt
@@ -14,18 +14,14 @@
  * limitations under the License.
  */
 
-package dev.shreyaspatil.noty.composeapp.view
+package dev.shreyaspatil.noty.composeapp.ui.theme
 
-sealed class Screen(val route: String, val name: String) {
-    object SignUp : Screen("signup", "Sign Up")
-    object Login : Screen("login", "Login")
-    object Notes : Screen("notes", "Notes")
-    object NotesDetail : Screen("note/{noteId}", "Note details") {
-        fun route(noteId: String) = "note/$noteId"
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.Shapes
+import androidx.compose.ui.unit.dp
 
-        const val ARG_NOTE_ID: String = "noteId"
-    }
-
-    object AddNote : Screen("note/new", "New note")
-    object About : Screen("about", "About")
-}
+val shapes = Shapes(
+    small = RoundedCornerShape(4.dp),
+    medium = RoundedCornerShape(4.dp),
+    large = RoundedCornerShape(0.dp)
+)

--- a/noty-android/app/composeapp/src/main/java/dev/shreyaspatil/noty/composeapp/ui/theme/Theme.kt
+++ b/noty-android/app/composeapp/src/main/java/dev/shreyaspatil/noty/composeapp/ui/theme/Theme.kt
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package dev.shreyaspatil.noty.composeapp.ui
+package dev.shreyaspatil.noty.composeapp.ui.theme
 
 import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.material.MaterialTheme

--- a/noty-android/app/composeapp/src/main/java/dev/shreyaspatil/noty/composeapp/ui/theme/Type.kt
+++ b/noty-android/app/composeapp/src/main/java/dev/shreyaspatil/noty/composeapp/ui/theme/Type.kt
@@ -14,11 +14,13 @@
  * limitations under the License.
  */
 
-package dev.shreyaspatil.noty.composeapp.ui
+package dev.shreyaspatil.noty.composeapp.ui.theme
 
 import androidx.compose.material.Typography
 import androidx.compose.ui.text.TextStyle
-import androidx.compose.ui.text.font.*
+import androidx.compose.ui.text.font.Font
+import androidx.compose.ui.text.font.FontFamily
+import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.sp
 import dev.shreyaspatil.noty.composeapp.R
 

--- a/noty-android/app/composeapp/src/main/java/dev/shreyaspatil/noty/composeapp/utils/AssistedViewModelUtils.kt
+++ b/noty-android/app/composeapp/src/main/java/dev/shreyaspatil/noty/composeapp/utils/AssistedViewModelUtils.kt
@@ -49,4 +49,3 @@ fun assistedViewModelFactory() = EntryPointAccessors.fromActivity(
     LocalContext.current as Activity,
     MainActivity.ViewModelFactoryProvider::class.java
 )
-

--- a/noty-android/app/composeapp/src/main/java/dev/shreyaspatil/noty/composeapp/utils/AssistedViewModelUtils.kt
+++ b/noty-android/app/composeapp/src/main/java/dev/shreyaspatil/noty/composeapp/utils/AssistedViewModelUtils.kt
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2020 Shreyas Patil
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package dev.shreyaspatil.noty.composeapp.utils
+
+import android.app.Activity
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.platform.LocalContext
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.ViewModelProvider
+import androidx.lifecycle.ViewModelStoreOwner
+import androidx.lifecycle.viewmodel.compose.LocalViewModelStoreOwner
+import androidx.lifecycle.viewmodel.compose.viewModel
+import dagger.hilt.android.EntryPointAccessors
+import dev.shreyaspatil.noty.composeapp.ui.MainActivity
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.InternalCoroutinesApi
+
+@ExperimentalCoroutinesApi
+@InternalCoroutinesApi
+@Composable
+inline fun <reified VM : ViewModel> assistedViewModel(
+    viewModelStoreOwner: ViewModelStoreOwner = checkNotNull(LocalViewModelStoreOwner.current) {
+        "No ViewModelStoreOwner was provided via LocalViewModelStoreOwner"
+    },
+    provideFactory: MainActivity.ViewModelFactoryProvider.() -> ViewModelProvider.Factory,
+): VM {
+    val factory = provideFactory(assistedViewModelFactory())
+    return viewModel(viewModelStoreOwner, factory = factory)
+}
+
+@ExperimentalCoroutinesApi
+@InternalCoroutinesApi
+@Composable
+fun assistedViewModelFactory() = EntryPointAccessors.fromActivity(
+    LocalContext.current as Activity,
+    MainActivity.ViewModelFactoryProvider::class.java
+)
+

--- a/noty-android/app/composeapp/src/main/java/dev/shreyaspatil/noty/composeapp/view/screen/LoginScreen.kt
+++ b/noty-android/app/composeapp/src/main/java/dev/shreyaspatil/noty/composeapp/view/screen/LoginScreen.kt
@@ -47,7 +47,6 @@ import androidx.compose.ui.text.SpanStyle
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.buildAnnotatedString
 import androidx.compose.ui.text.input.PasswordVisualTransformation
-import androidx.compose.ui.text.input.TextFieldValue
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.constraintlayout.compose.ConstraintLayout
@@ -55,8 +54,8 @@ import androidx.navigation.NavHostController
 import dev.shreyaspatil.noty.composeapp.R.drawable.noty_app_logo
 import dev.shreyaspatil.noty.composeapp.component.dialog.FailureDialog
 import dev.shreyaspatil.noty.composeapp.component.dialog.LoaderDialog
-import dev.shreyaspatil.noty.composeapp.ui.typography
-import dev.shreyaspatil.noty.composeapp.view.Screen
+import dev.shreyaspatil.noty.composeapp.ui.Screen
+import dev.shreyaspatil.noty.composeapp.ui.theme.typography
 import dev.shreyaspatil.noty.core.view.ViewState
 import dev.shreyaspatil.noty.utils.validator.AuthValidator
 import dev.shreyaspatil.noty.view.viewmodel.LoginViewModel
@@ -72,7 +71,10 @@ fun LoginScreen(navController: NavHostController, loginViewModel: LoginViewModel
         is ViewState.Loading -> LoaderDialog()
         is ViewState.Failed -> FailureDialog(viewState.message)
         is ViewState.Success -> {
-            navController.navigateUp()
+            navController.navigate(Screen.Notes.route) {
+                launchSingleTop = true
+                popUpTo(Screen.Login.route) { inclusive = true }
+            }
         }
     }
 
@@ -113,15 +115,16 @@ fun LoginScreen(navController: NavHostController, loginViewModel: LoginViewModel
                         start.linkTo(parent.start, margin = 16.dp)
                     }
                 )
-                var username by remember { mutableStateOf(TextFieldValue()) }
-                val isValidUsername = AuthValidator.isValidUsername(username.text)
+                var username by remember { mutableStateOf("") }
+                val isValidUsername = AuthValidator.isValidUsername(username)
                 TextField(
                     modifier = Modifier
                         .fillMaxWidth()
                         .padding(16.dp, 0.dp, 16.dp, 0.dp)
                         .constrainAs(usernameRef) {
                             top.linkTo(titleRef.bottom, margin = 30.dp)
-                        }.background(MaterialTheme.colors.background),
+                        }
+                        .background(MaterialTheme.colors.background),
                     label = { Text(text = "Username") },
                     leadingIcon = { Icon(Icons.Outlined.Person, "User") },
                     textStyle = TextStyle(
@@ -135,8 +138,8 @@ fun LoginScreen(navController: NavHostController, loginViewModel: LoginViewModel
                     isError = !isValidUsername
                 )
 
-                var password by remember { mutableStateOf(TextFieldValue()) }
-                val isValidPassword = AuthValidator.isValidPassword(password.text)
+                var password by remember { mutableStateOf("") }
+                val isValidPassword = AuthValidator.isValidPassword(password)
 
                 TextField(
                     modifier = Modifier
@@ -144,7 +147,8 @@ fun LoginScreen(navController: NavHostController, loginViewModel: LoginViewModel
                         .padding(16.dp, 0.dp, 16.dp, 0.dp)
                         .constrainAs(passwordRef) {
                             top.linkTo(usernameRef.bottom, margin = 16.dp)
-                        }.background(MaterialTheme.colors.background),
+                        }
+                        .background(MaterialTheme.colors.background),
                     label = { Text(text = "Password") },
                     leadingIcon = { Icon(Icons.Outlined.Lock, "Password") },
                     textStyle = TextStyle(
@@ -162,7 +166,7 @@ fun LoginScreen(navController: NavHostController, loginViewModel: LoginViewModel
                 Button(
                     onClick = {
                         if (isValidUsername && isValidPassword) {
-                            loginViewModel.login(username.text, password.text)
+                            loginViewModel.login(username, password)
                         }
                     },
                     modifier = Modifier
@@ -188,7 +192,8 @@ fun LoginScreen(navController: NavHostController, loginViewModel: LoginViewModel
                             top.linkTo(buttonSignupRef.bottom, margin = 24.dp)
                             start.linkTo(parent.start, margin = 16.dp)
                             end.linkTo(parent.end, margin = 16.dp)
-                        }.clickable(
+                        }
+                        .clickable(
                             onClick = {
                                 navController.navigate(Screen.SignUp.route)
                             }

--- a/noty-android/app/src/main/java/dev/shreyaspatil/noty/view/viewmodel/NoteDetailViewModel.kt
+++ b/noty-android/app/src/main/java/dev/shreyaspatil/noty/view/viewmodel/NoteDetailViewModel.kt
@@ -16,6 +16,7 @@
 
 package dev.shreyaspatil.noty.view.viewmodel
 
+import android.util.Log
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.ViewModelProvider
 import androidx.lifecycle.viewModelScope
@@ -117,6 +118,11 @@ class NoteDetailViewModel @AssistedInject constructor(
 
     private fun scheduleNoteDelete(noteId: String) =
         notyTaskManager.scheduleTask(NotyTask.delete(noteId))
+
+    override fun onCleared() {
+        super.onCleared()
+        Log.d("NoteDetailViewModel", "onCleared")
+    }
 
     @AssistedFactory
     interface Factory {

--- a/noty-android/dependencies.gradle
+++ b/noty-android/dependencies.gradle
@@ -34,7 +34,7 @@ ext {
     navigationVersion = "2.3.5"
     securityCryptoVersion = '1.1.0-alpha03'
     roomVersion = "2.3.0"
-    dataStoreVersion = '1.0.0-rc01'
+    dataStoreVersion = '1.0.0-rc02'
     legacySupportVersion = "1.0.0"
 
     // Design
@@ -71,6 +71,8 @@ ext {
 
     // Hilt Compose Navigation
     hiltComposeNavVersion = "1.0.0-alpha03"
+
+    lifecycleViewModelComposeVersion = "1.0.0-alpha07"
 
     // Testing
     jUnitVersion = "4.13.2"

--- a/noty-android/dependencies.gradle
+++ b/noty-android/dependencies.gradle
@@ -16,7 +16,7 @@
 
 ext {
     // Android Plugin
-    androidGradlePluginVersion = '7.0.0-beta05'
+    androidGradlePluginVersion = '7.0.0'
 
     // Kotlin
     kotlinVersion = "1.5.10"
@@ -24,7 +24,7 @@ ext {
     coroutinesVersion = "1.5.0"
 
     // Android
-    appcompatVersion = "1.3.0"
+    appcompatVersion = "1.3.1"
     coreKtxVersion = "1.6.0"
     constraintlayoutVersion = "2.0.4"
     swipeRefreshLayoutVersion = "1.1.0"
@@ -41,10 +41,10 @@ ext {
     materialDesignVersion = "1.4.0"
 
     // Lottie Animation
-    lottieVersion = "3.7.0"
+    lottieVersion = "4.0.0"
 
     // Lottie Animation (Compose)
-    lottieComposeVersion = "1.0.0-beta07-1"
+    lottieComposeVersion = "4.0.0"
 
     // DI
     daggerHiltVersion = "2.37"
@@ -54,20 +54,20 @@ ext {
     retrofitVersion = "2.9.0"
 
     // Moshi
-    moshiVersion = "1.11.0"
+    moshiVersion = "1.12.0"
 
     // Other utility
     leakCanaryVersion = "2.6"
     javaxInjectVersion = "1"
 
     // Jetpack Compose
-    composeVersion = "1.0.0-rc02"
+    composeVersion = "1.0.0"
 
     // Constrain Layout (Compose)
-    composeConstraintLayoutVersion = "1.0.0-alpha07"
+    composeConstraintLayoutVersion = "1.0.0-beta01"
 
     // Jetpack Compose Navigation
-    composeNavVersion = "2.4.0-alpha04"
+    composeNavVersion = "2.4.0-alpha05"
 
     // Hilt Compose Navigation
     hiltComposeNavVersion = "1.0.0-alpha03"


### PR DESCRIPTION
## Summary

- Updated composeapp to use Jetpack Compose v1.0.0
- Fixed part of code w.r.t migration
- Move classes to appropriate sub-packages of `ui`.
- Added utility for Assisted Inject-able ViewModel _(as per the suggestion of @steurt)_

## Description for the changelog

- Bumped Android Gradle Plugin version
- Bumped Gradle wrapper version
- Bumped dependency versions
- Bumped Jetpack Compose version to 1.0.0
- Fixed code for Lottie Animation w.r.t changes made in Lottie 4.0.0
- Instead of having `view` package, moved everything to `ui` package from now.
- Added utility for Assisted Inject-able ViewModel which is now more generic _(as per discussed here https://github.com/PatilShreyas/NotyKT/discussions/179)_
- Fixed navigation component issue.

## Checklist

<!--
The current CI workflow will validate code level changes. 
Make sure that `./gradlew build` is passing before raising a PR. If build is failing at linting then just 
execute `./gradlew ktlintFormat` which will reformat code according to our code standards.
Other than this, it's encouraged if you pay attention to the below checklist.
-->

- [x] Build and linting is passing.
- [x] This change is not breaking existing flow of a system.
- [ ] I have written test case for this change.
- [x] This change is tested from all aspects.
- [ ] Implemented any new third-party library _(Which not existed before this change)_.

---

## Fixes/Closes

- #151: Compose navigation now comes with in-built transition support
