### PR TITLE
Improvements for Compose App

### DIFF
--- a/docs/pages/noty-android/getting-started.md
+++ b/docs/pages/noty-android/getting-started.md
@@ -86,4 +86,6 @@ For single source of data. Implements `local` and `remote` modules.
 
 - [Jetpack Compose UI Toolkit](https://developer.android.com/jetpack/compose) - Modern UI development toolkit.
 
+- [Accompanist](https://google.github.io/accompanist/) - Accompanist is a group of libraries that aim to supplement Jetpack Compose with features that are commonly required by developers but not yet available.
+
 - [LeakCanary](https://square.github.io/leakcanary/) - Memory leak detection library for Android

--- a/noty-android/README.md
+++ b/noty-android/README.md
@@ -81,6 +81,7 @@ Design of this awesome application is implemented by [Sanju S](https://github.co
 - [Moshi Converter](https://github.com/square/retrofit/tree/master/retrofit-converters/moshi) - A Converter which uses Moshi for serialization to and from JSON.
 - [Material Components for Android](https://github.com/material-components/material-components-android) - Modular and customizable Material Design UI components for Android.
 - [Jetpack Compose UI Toolkit](https://developer.android.com/jetpack/compose) - Modern UI development toolkit.
+- [Accompanist](https://google.github.io/accompanist/) - Accompanist is a group of libraries that aim to supplement Jetpack Compose with features that are commonly required by developers but not yet available.
 - [LeakCanary](https://square.github.io/leakcanary/) - Memory leak detection library for Android
 
 ## Modules

--- a/noty-android/app/composeapp/build.gradle
+++ b/noty-android/app/composeapp/build.gradle
@@ -143,6 +143,9 @@ dependencies {
     // Compose Lifecycle
     implementation "androidx.compose.runtime:runtime-livedata:$composeVersion"
 
+    // Accompanist
+    implementation "com.google.accompanist:accompanist-swiperefresh:$accompanistVersion"
+
     // Navigation
     implementation "androidx.navigation:navigation-compose:$composeNavVersion"
 

--- a/noty-android/app/composeapp/src/main/java/dev/shreyaspatil/noty/composeapp/component/text/CommonTextField.kt
+++ b/noty-android/app/composeapp/src/main/java/dev/shreyaspatil/noty/composeapp/component/text/CommonTextField.kt
@@ -50,5 +50,3 @@ fun NotyTextField(
         visualTransformation = visualTransformation
     )
 }
-
-

--- a/noty-android/app/composeapp/src/main/java/dev/shreyaspatil/noty/composeapp/component/text/CommonTextField.kt
+++ b/noty-android/app/composeapp/src/main/java/dev/shreyaspatil/noty/composeapp/component/text/CommonTextField.kt
@@ -16,16 +16,25 @@
 
 package dev.shreyaspatil.noty.composeapp.component.text
 
+import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.animation.ExperimentalAnimationApi
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.text.BasicTextField
 import androidx.compose.material.MaterialTheme
 import androidx.compose.material.OutlinedTextField
 import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.SolidColor
 import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.input.VisualTransformation
 import androidx.compose.ui.unit.TextUnit
+import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import dev.shreyaspatil.noty.composeapp.ui.theme.getTextFieldHintColor
 
 @Composable
 fun NotyTextField(
@@ -49,4 +58,34 @@ fun NotyTextField(
         isError = isError,
         visualTransformation = visualTransformation
     )
+}
+
+@ExperimentalAnimationApi
+@Composable
+fun BasicNotyTextField(
+    modifier: Modifier = Modifier,
+    value: String = "",
+    label: String = "",
+    textStyle: TextStyle = TextStyle(fontSize = 16.sp, fontWeight = FontWeight.Normal),
+    onTextChange: (String) -> Unit,
+    maxLines: Int = Int.MAX_VALUE
+) {
+
+    Box(modifier = modifier.padding(4.dp)) {
+        AnimatedVisibility(visible = value.isBlank()) {
+            Text(
+                text = label,
+                color = getTextFieldHintColor(),
+                fontSize = textStyle.fontSize,
+                fontWeight = textStyle.fontWeight
+            )
+        }
+        BasicTextField(
+            value = value,
+            onValueChange = onTextChange,
+            textStyle = textStyle.copy(color = MaterialTheme.colors.onPrimary),
+            maxLines = maxLines,
+            cursorBrush = SolidColor(MaterialTheme.colors.primary)
+        )
+    }
 }

--- a/noty-android/app/composeapp/src/main/java/dev/shreyaspatil/noty/composeapp/component/text/CommonTextField.kt
+++ b/noty-android/app/composeapp/src/main/java/dev/shreyaspatil/noty/composeapp/component/text/CommonTextField.kt
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2020 Shreyas Patil
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package dev.shreyaspatil.noty.composeapp.component.text
+
+import androidx.compose.material.MaterialTheme
+import androidx.compose.material.OutlinedTextField
+import androidx.compose.material.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.text.input.VisualTransformation
+import androidx.compose.ui.unit.TextUnit
+import androidx.compose.ui.unit.sp
+
+@Composable
+fun NotyTextField(
+    value: String,
+    label: String,
+    onValueChange: (String) -> Unit,
+    modifier: Modifier = Modifier,
+    fontSize: TextUnit = 16.sp,
+    color: Color = MaterialTheme.colors.onPrimary,
+    leadingIcon: @Composable() (() -> Unit)? = null,
+    isError: Boolean = false,
+    visualTransformation: VisualTransformation = VisualTransformation.None
+) {
+    OutlinedTextField(
+        value = value,
+        label = { Text(text = label) },
+        modifier = modifier,
+        onValueChange = onValueChange,
+        leadingIcon = leadingIcon,
+        textStyle = TextStyle(color, fontSize = fontSize),
+        isError = isError,
+        visualTransformation = visualTransformation
+    )
+}
+
+

--- a/noty-android/app/composeapp/src/main/java/dev/shreyaspatil/noty/composeapp/component/text/NoteTextFields.kt
+++ b/noty-android/app/composeapp/src/main/java/dev/shreyaspatil/noty/composeapp/component/text/NoteTextFields.kt
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2020 Shreyas Patil
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package dev.shreyaspatil.noty.composeapp.component.text
+
+import androidx.compose.animation.ExperimentalAnimationApi
+import androidx.compose.material.MaterialTheme
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.sp
+
+@ExperimentalAnimationApi
+@Composable
+fun NoteTitleField(
+    modifier: Modifier = Modifier,
+    value: String = "",
+    onTextChange: (String) -> Unit
+) {
+    BasicNotyTextField(
+        modifier,
+        value = value,
+        label = "Title",
+        onTextChange = onTextChange,
+        textStyle = MaterialTheme.typography.h6,
+        maxLines = 2
+    )
+
+}
+
+@ExperimentalAnimationApi
+@Composable
+fun NoteField(
+    modifier: Modifier = Modifier,
+    value: String = "",
+    onTextChange: (String) -> Unit
+) {
+    BasicNotyTextField(
+        modifier,
+        value = value,
+        label = "Write here",
+        onTextChange = onTextChange,
+        textStyle = TextStyle(fontSize = 18.sp, fontWeight = FontWeight.Light)
+    )
+
+}

--- a/noty-android/app/composeapp/src/main/java/dev/shreyaspatil/noty/composeapp/component/text/NoteTextFields.kt
+++ b/noty-android/app/composeapp/src/main/java/dev/shreyaspatil/noty/composeapp/component/text/NoteTextFields.kt
@@ -39,7 +39,6 @@ fun NoteTitleField(
         textStyle = MaterialTheme.typography.h6,
         maxLines = 2
     )
-
 }
 
 @ExperimentalAnimationApi
@@ -56,5 +55,4 @@ fun NoteField(
         onTextChange = onTextChange,
         textStyle = TextStyle(fontSize = 18.sp, fontWeight = FontWeight.Light)
     )
-
 }

--- a/noty-android/app/composeapp/src/main/java/dev/shreyaspatil/noty/composeapp/component/text/PasswordTextField.kt
+++ b/noty-android/app/composeapp/src/main/java/dev/shreyaspatil/noty/composeapp/component/text/PasswordTextField.kt
@@ -1,0 +1,83 @@
+/*
+ * Copyright 2020 Shreyas Patil
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package dev.shreyaspatil.noty.composeapp.component.text
+
+import androidx.compose.material.Icon
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.outlined.Password
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.input.PasswordVisualTransformation
+import dev.shreyaspatil.noty.utils.validator.AuthValidator.isPasswordAndConfirmPasswordSame
+import dev.shreyaspatil.noty.utils.validator.AuthValidator.isValidPassword
+
+@Composable
+fun PasswordTextField(
+    modifier: Modifier = Modifier,
+    value: String = "",
+    onTextChange: (TextFieldValue<String>) -> Unit,
+) {
+    var startedTyping by remember { mutableStateOf(false) }
+    var isValid by remember { mutableStateOf(false) }
+
+    NotyTextField(
+        value = value,
+        label = "Password",
+        onValueChange = {
+            isValid = isValidPassword(it)
+            onTextChange(if (isValid) TextFieldValue.Valid(it) else TextFieldValue.Invalid(it))
+            if (!startedTyping) {
+                startedTyping = true
+            }
+        },
+        modifier = modifier,
+        leadingIcon = { Icon(Icons.Outlined.Password, "Password") },
+        visualTransformation = PasswordVisualTransformation(),
+        isError = !isValid && startedTyping
+    )
+}
+
+@Composable
+fun ConfirmPasswordTextField(
+    modifier: Modifier = Modifier,
+    value: String = "",
+    expectedValue: String = "",
+    onTextChange: (TextFieldValue<String>) -> Unit,
+) {
+    var startedTyping by remember { mutableStateOf(false) }
+    var isValid by remember { mutableStateOf(false) }
+
+    NotyTextField(
+        value = value,
+        label = "Confirm Password",
+        onValueChange = {
+            isValid = isValidPassword(it) && isPasswordAndConfirmPasswordSame(expectedValue, it)
+            onTextChange(if (isValid) TextFieldValue.Valid(it) else TextFieldValue.Invalid(it))
+            if (!startedTyping) {
+                startedTyping = true
+            }
+        },
+        modifier = modifier,
+        leadingIcon = { Icon(Icons.Outlined.Password, "Confirm Password") },
+        visualTransformation = PasswordVisualTransformation(),
+        isError = !isValid && startedTyping
+    )
+}

--- a/noty-android/app/composeapp/src/main/java/dev/shreyaspatil/noty/composeapp/component/text/TextFieldValue.kt
+++ b/noty-android/app/composeapp/src/main/java/dev/shreyaspatil/noty/composeapp/component/text/TextFieldValue.kt
@@ -1,0 +1,22 @@
+/*
+ * Copyright 2020 Shreyas Patil
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package dev.shreyaspatil.noty.composeapp.component.text
+
+sealed class TextFieldValue<T>(val data: T) {
+    class Valid<T>(data: T) : TextFieldValue<T>(data)
+    class Invalid<T>(data: T) : TextFieldValue<T>(data)
+}

--- a/noty-android/app/composeapp/src/main/java/dev/shreyaspatil/noty/composeapp/component/text/UsernameTextField.kt
+++ b/noty-android/app/composeapp/src/main/java/dev/shreyaspatil/noty/composeapp/component/text/UsernameTextField.kt
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2020 Shreyas Patil
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package dev.shreyaspatil.noty.composeapp.component.text
+
+import androidx.compose.material.Icon
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.outlined.Person
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import dev.shreyaspatil.noty.utils.validator.AuthValidator
+
+@Composable
+fun UsernameTextField(
+    modifier: Modifier = Modifier,
+    value: String = "",
+    onTextChange: (TextFieldValue<String>) -> Unit,
+) {
+    var startedTyping by remember { mutableStateOf(false) }
+    var isValid by remember { mutableStateOf(false) }
+
+    NotyTextField(
+        value = value,
+        label = "Username",
+        onValueChange = {
+            isValid = AuthValidator.isValidUsername(it)
+            onTextChange(if (isValid) TextFieldValue.Valid(it) else TextFieldValue.Invalid(it))
+            if (!startedTyping) {
+                startedTyping = true
+            }
+        },
+        modifier = modifier,
+        leadingIcon = { Icon(Icons.Outlined.Person, "User") },
+        isError = !isValid && startedTyping
+    )
+}

--- a/noty-android/app/composeapp/src/main/java/dev/shreyaspatil/noty/composeapp/navigation/NotyNavigation.kt
+++ b/noty-android/app/composeapp/src/main/java/dev/shreyaspatil/noty/composeapp/navigation/NotyNavigation.kt
@@ -16,6 +16,7 @@
 
 package dev.shreyaspatil.noty.composeapp.navigation
 
+import androidx.compose.animation.ExperimentalAnimationApi
 import androidx.compose.runtime.Composable
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.navigation.NavType
@@ -37,6 +38,7 @@ import kotlinx.coroutines.InternalCoroutinesApi
 
 const val NOTY_NAV_HOST_ROUTE = "noty-main-route"
 
+@ExperimentalAnimationApi
 @InternalCoroutinesApi
 @ExperimentalCoroutinesApi
 @Composable

--- a/noty-android/app/composeapp/src/main/java/dev/shreyaspatil/noty/composeapp/navigation/NotyNavigation.kt
+++ b/noty-android/app/composeapp/src/main/java/dev/shreyaspatil/noty/composeapp/navigation/NotyNavigation.kt
@@ -40,7 +40,7 @@ const val NOTY_NAV_HOST_ROUTE = "noty-main-route"
 @InternalCoroutinesApi
 @ExperimentalCoroutinesApi
 @Composable
-fun NotyNavigation(toggleTheme: () -> Unit) {
+fun NotyNavigation() {
     val navController = rememberNavController()
 
     NavHost(navController, startDestination = Screen.Notes.route, route = NOTY_NAV_HOST_ROUTE) {
@@ -54,7 +54,7 @@ fun NotyNavigation(toggleTheme: () -> Unit) {
             AddNoteScreen(navController, hiltViewModel())
         }
         composable(Screen.Notes.route) {
-            NotesScreen(toggleTheme, navController, hiltViewModel())
+            NotesScreen(navController, hiltViewModel())
         }
         composable(
             Screen.NotesDetail.route,

--- a/noty-android/app/composeapp/src/main/java/dev/shreyaspatil/noty/composeapp/ui/MainActivity.kt
+++ b/noty-android/app/composeapp/src/main/java/dev/shreyaspatil/noty/composeapp/ui/MainActivity.kt
@@ -26,7 +26,6 @@ import androidx.compose.material.Surface
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
-import androidx.compose.ui.tooling.preview.Preview
 import androidx.lifecycle.lifecycleScope
 import dagger.hilt.EntryPoint
 import dagger.hilt.InstallIn
@@ -87,10 +86,4 @@ class MainActivity : AppCompatActivity() {
             }
         }
     }
-}
-
-@Preview(showBackground = true)
-@Composable
-fun DefaultPreview() {
-    NotyTheme {}
 }

--- a/noty-android/app/composeapp/src/main/java/dev/shreyaspatil/noty/composeapp/ui/MainActivity.kt
+++ b/noty-android/app/composeapp/src/main/java/dev/shreyaspatil/noty/composeapp/ui/MainActivity.kt
@@ -20,6 +20,7 @@ import android.os.Bundle
 import androidx.activity.compose.setContent
 import androidx.appcompat.app.AppCompatActivity
 import androidx.appcompat.app.AppCompatDelegate
+import androidx.compose.animation.ExperimentalAnimationApi
 import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.material.MaterialTheme
 import androidx.compose.material.Surface
@@ -41,6 +42,7 @@ import kotlinx.coroutines.InternalCoroutinesApi
 import kotlinx.coroutines.flow.collect
 import javax.inject.Inject
 
+@ExperimentalAnimationApi
 @AndroidEntryPoint
 @ExperimentalCoroutinesApi
 @InternalCoroutinesApi

--- a/noty-android/app/composeapp/src/main/java/dev/shreyaspatil/noty/composeapp/ui/MainActivity.kt
+++ b/noty-android/app/composeapp/src/main/java/dev/shreyaspatil/noty/composeapp/ui/MainActivity.kt
@@ -40,7 +40,6 @@ import dev.shreyaspatil.noty.view.viewmodel.NoteDetailViewModel
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.InternalCoroutinesApi
 import kotlinx.coroutines.flow.collect
-import kotlinx.coroutines.launch
 import javax.inject.Inject
 
 @AndroidEntryPoint
@@ -70,22 +69,17 @@ class MainActivity : AppCompatActivity() {
     private fun NotyMain() {
         val darkMode by preferenceManager.uiModeFlow.collectAsState(initial = isSystemInDarkTheme())
 
-        val toggleTheme: () -> Unit = {
-            lifecycleScope.launch { preferenceManager.setDarkMode(!darkMode) }
-        }
-
         NotyTheme(darkTheme = darkMode) {
-            // A surface container using the 'background' color from the theme
             Surface(color = MaterialTheme.colors.background) {
-                NotyNavigation(toggleTheme = toggleTheme)
+                NotyNavigation()
             }
         }
     }
 
     private fun observeUiTheme() {
         lifecycleScope.launchWhenStarted {
-            preferenceManager.uiModeFlow.collect {
-                val mode = when (it) {
+            preferenceManager.uiModeFlow.collect { isDarkMode ->
+                val mode = when (isDarkMode) {
                     true -> AppCompatDelegate.MODE_NIGHT_YES
                     false -> AppCompatDelegate.MODE_NIGHT_NO
                 }

--- a/noty-android/app/composeapp/src/main/java/dev/shreyaspatil/noty/composeapp/ui/screens/AddNotesScreen.kt
+++ b/noty-android/app/composeapp/src/main/java/dev/shreyaspatil/noty/composeapp/ui/screens/AddNotesScreen.kt
@@ -49,7 +49,7 @@ import dev.shreyaspatil.noty.composeapp.component.dialog.FailureDialog
 import dev.shreyaspatil.noty.composeapp.component.dialog.LoaderDialog
 import dev.shreyaspatil.noty.composeapp.component.text.NoteField
 import dev.shreyaspatil.noty.composeapp.component.text.NoteTitleField
-import dev.shreyaspatil.noty.core.view.ViewState
+import dev.shreyaspatil.noty.core.ui.UIDataState
 import dev.shreyaspatil.noty.utils.validator.NoteValidator
 import dev.shreyaspatil.noty.view.viewmodel.AddNoteViewModel
 import kotlinx.coroutines.ExperimentalCoroutinesApi
@@ -67,9 +67,9 @@ fun AddNoteScreen(
     val addNoteState = viewModel.addNoteState.collectAsState(initial = null).value
 
     when (addNoteState) {
-        is ViewState.Loading -> LoaderDialog()
-        is ViewState.Success -> navController.navigateUp()
-        is ViewState.Failed -> FailureDialog(addNoteState.message)
+        is UIDataState.Loading -> LoaderDialog()
+        is UIDataState.Success -> navController.navigateUp()
+        is UIDataState.Failed -> FailureDialog(addNoteState.message)
     }
 
     Scaffold(

--- a/noty-android/app/composeapp/src/main/java/dev/shreyaspatil/noty/composeapp/ui/screens/AddNotesScreen.kt
+++ b/noty-android/app/composeapp/src/main/java/dev/shreyaspatil/noty/composeapp/ui/screens/AddNotesScreen.kt
@@ -16,18 +16,21 @@
 
 package dev.shreyaspatil.noty.composeapp.ui.screens
 
+import androidx.compose.animation.ExperimentalAnimationApi
 import androidx.compose.foundation.background
+import androidx.compose.foundation.gestures.Orientation
+import androidx.compose.foundation.gestures.scrollable
+import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.rememberScrollState
 import androidx.compose.material.ExtendedFloatingActionButton
 import androidx.compose.material.Icon
 import androidx.compose.material.IconButton
 import androidx.compose.material.MaterialTheme
 import androidx.compose.material.Scaffold
 import androidx.compose.material.Text
-import androidx.compose.material.TextField
 import androidx.compose.material.TopAppBar
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Done
@@ -38,20 +41,20 @@ import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.painterResource
-import androidx.compose.ui.text.TextStyle
-import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
-import androidx.compose.ui.unit.sp
 import androidx.navigation.NavHostController
 import dev.shreyaspatil.noty.composeapp.R
 import dev.shreyaspatil.noty.composeapp.component.dialog.FailureDialog
 import dev.shreyaspatil.noty.composeapp.component.dialog.LoaderDialog
+import dev.shreyaspatil.noty.composeapp.component.text.NoteField
+import dev.shreyaspatil.noty.composeapp.component.text.NoteTitleField
 import dev.shreyaspatil.noty.core.view.ViewState
 import dev.shreyaspatil.noty.utils.validator.NoteValidator
 import dev.shreyaspatil.noty.view.viewmodel.AddNoteViewModel
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 
+@ExperimentalAnimationApi
 @ExperimentalCoroutinesApi
 @Composable
 fun AddNoteScreen(
@@ -74,7 +77,7 @@ fun AddNoteScreen(
             TopAppBar(
                 title = {
                     Text(
-                        text = "Noty",
+                        text = "Add Note",
                         textAlign = TextAlign.Start,
                         color = MaterialTheme.colors.onPrimary,
                         modifier = Modifier.fillMaxWidth()
@@ -82,7 +85,7 @@ fun AddNoteScreen(
                 },
                 navigationIcon = {
                     IconButton(
-                        modifier = Modifier.padding(12.dp, 0.dp, 0.dp, 0.dp),
+                        modifier = Modifier.padding(4.dp, 0.dp, 0.dp, 0.dp),
                         onClick = {
                             navController.navigateUp()
                         }
@@ -100,39 +103,31 @@ fun AddNoteScreen(
             )
         },
         content = {
-            LazyColumn {
-                item {
-                    TextField(
-                        modifier = Modifier
-                            .fillMaxWidth()
-                            .padding(16.dp, 0.dp, 16.dp, 0.dp)
-                            .background(MaterialTheme.colors.background),
-                        label = { Text(text = "Title") },
-                        textStyle = TextStyle(
-                            color = MaterialTheme.colors.onPrimary,
-                            fontWeight = FontWeight.Bold,
-                            fontSize = 24.sp
-                        ),
-                        value = titleText.value,
-                        onValueChange = { titleText.value = it }
-                    )
-                }
-                item {
-                    TextField(
-                        modifier = Modifier
-                            .fillMaxWidth()
-                            .fillMaxHeight()
-                            .padding(16.dp, 0.dp, 16.dp, 0.dp)
-                            .background(MaterialTheme.colors.background),
-                        label = { Text(text = "Write something...") },
-                        textStyle = TextStyle(
-                            color = MaterialTheme.colors.onPrimary,
-                            fontSize = 16.sp
-                        ),
-                        value = noteText.value,
-                        onValueChange = { noteText.value = it }
-                    )
-                }
+            Column(
+                Modifier.scrollable(
+                    rememberScrollState(),
+                    orientation = Orientation.Vertical
+                )
+            ) {
+
+                NoteTitleField(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(16.dp, 0.dp, 16.dp, 0.dp)
+                        .background(MaterialTheme.colors.background),
+                    value = titleText.value,
+                    onTextChange = { titleText.value = it },
+                )
+
+                NoteField(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .fillMaxHeight()
+                        .padding(16.dp, 8.dp, 16.dp, 0.dp)
+                        .background(MaterialTheme.colors.background),
+                    value = noteText.value,
+                    onTextChange = { noteText.value = it }
+                )
             }
         },
         floatingActionButton = {

--- a/noty-android/app/composeapp/src/main/java/dev/shreyaspatil/noty/composeapp/ui/screens/NoteDetailsScreen.kt
+++ b/noty-android/app/composeapp/src/main/java/dev/shreyaspatil/noty/composeapp/ui/screens/NoteDetailsScreen.kt
@@ -18,41 +18,44 @@ package dev.shreyaspatil.noty.composeapp.ui.screens
 
 import android.app.Activity
 import android.content.Intent
+import androidx.compose.animation.ExperimentalAnimationApi
 import androidx.compose.foundation.background
-import androidx.compose.foundation.layout.fillMaxHeight
+import androidx.compose.foundation.gestures.Orientation
+import androidx.compose.foundation.gestures.scrollable
+import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.layout.wrapContentHeight
+import androidx.compose.foundation.rememberScrollState
 import androidx.compose.material.ExtendedFloatingActionButton
 import androidx.compose.material.Icon
 import androidx.compose.material.IconButton
 import androidx.compose.material.MaterialTheme
 import androidx.compose.material.Scaffold
 import androidx.compose.material.Text
-import androidx.compose.material.TextField
 import androidx.compose.material.TopAppBar
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Done
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.painterResource
-import androidx.compose.ui.text.TextStyle
-import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
-import androidx.compose.ui.unit.sp
 import androidx.core.app.ShareCompat
 import androidx.navigation.NavHostController
 import dev.shreyaspatil.noty.composeapp.R
 import dev.shreyaspatil.noty.composeapp.component.action.DeleteAction
 import dev.shreyaspatil.noty.composeapp.component.action.ShareAction
 import dev.shreyaspatil.noty.composeapp.component.dialog.FailureDialog
-import dev.shreyaspatil.noty.composeapp.component.dialog.LoaderDialog
+import dev.shreyaspatil.noty.composeapp.component.text.NoteField
+import dev.shreyaspatil.noty.composeapp.component.text.NoteTitleField
 import dev.shreyaspatil.noty.composeapp.utils.ShowToast
 import dev.shreyaspatil.noty.core.view.ViewState
 import dev.shreyaspatil.noty.utils.validator.NoteValidator
@@ -60,6 +63,7 @@ import dev.shreyaspatil.noty.view.viewmodel.NoteDetailViewModel
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.InternalCoroutinesApi
 
+@ExperimentalAnimationApi
 @InternalCoroutinesApi
 @ExperimentalCoroutinesApi
 @Composable
@@ -74,11 +78,9 @@ fun NoteDetailsScreen(
 
     val note = viewModel.note.collectAsState(initial = null).value
 
-    if (note == null) {
-        LoaderDialog()
-    } else {
-        val titleText = remember { mutableStateOf(note.title) }
-        val noteText = remember { mutableStateOf(note.note) }
+    if (note != null) {
+        var titleText by remember { mutableStateOf(note.title) }
+        var noteText by remember { mutableStateOf(note.note) }
 
         Scaffold(
             topBar = {
@@ -93,10 +95,8 @@ fun NoteDetailsScreen(
                     },
                     navigationIcon = {
                         IconButton(
-                            modifier = Modifier.padding(12.dp, 0.dp, 0.dp, 0.dp),
-                            onClick = {
-                                navController.navigateUp()
-                            }
+                            modifier = Modifier.padding(4.dp, 0.dp, 0.dp, 0.dp),
+                            onClick = { navController.navigateUp() }
                         ) {
                             Icon(
                                 painterResource(R.drawable.ic_back),
@@ -110,59 +110,39 @@ fun NoteDetailsScreen(
                     elevation = 0.dp,
                     actions = {
                         DeleteAction(onClick = { viewModel.deleteNote() })
-                        ShareAction(
-                            onClick = {
-                                shareNote(
-                                    activity,
-                                    titleText.value,
-                                    noteText.value
-                                )
-                            }
-                        )
+                        ShareAction(onClick = { shareNote(activity, titleText, noteText) })
                     }
                 )
             },
             content = {
-                LazyColumn {
-                    item {
-                        TextField(
-                            modifier = Modifier
-                                .fillMaxWidth()
-                                .padding(16.dp, 0.dp, 16.dp, 0.dp)
-                                .background(MaterialTheme.colors.background),
-                            label = { Text(text = "Title") },
-                            textStyle = TextStyle(
-                                color = MaterialTheme.colors.onPrimary,
-                                fontWeight = FontWeight.Bold,
-                                fontSize = 24.sp
-                            ),
-                            value = titleText.value,
-                            onValueChange = { titleText.value = it }
-                        )
-                    }
-                    item {
-                        TextField(
-                            modifier = Modifier
-                                .fillMaxWidth()
-                                .fillMaxHeight()
-                                .padding(16.dp, 0.dp, 16.dp, 0.dp)
-                                .background(MaterialTheme.colors.background),
-                            label = { Text(text = "Write something...") },
-                            textStyle = TextStyle(
-                                color = MaterialTheme.colors.onPrimary,
-                                fontSize = 16.sp
-                            ),
-                            value = noteText.value,
-                            onValueChange = { noteText.value = it }
-                        )
-                    }
+                Column(
+                    Modifier.scrollable(
+                        rememberScrollState(),
+                        orientation = Orientation.Vertical
+                    )
+                ) {
+                    NoteTitleField(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .padding(16.dp, 0.dp, 16.dp, 0.dp)
+                            .background(MaterialTheme.colors.background),
+                        value = titleText,
+                        onTextChange = { titleText = it }
+                    )
+
+                    NoteField(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .wrapContentHeight()
+                            .padding(16.dp, 8.dp, 16.dp, 0.dp)
+                            .background(MaterialTheme.colors.background),
+                        value = noteText,
+                        onTextChange = { noteText = it }
+                    )
                 }
             },
             floatingActionButton = {
-                val noteTitle = titleText.value
-                val noteContent = noteText.value
-
-                if (NoteValidator.isValidNote(noteTitle, noteContent)) {
+                if (NoteValidator.isValidNote(titleText, noteText)) {
                     ExtendedFloatingActionButton(
                         text = { Text("Save", color = Color.White) },
                         icon = {
@@ -172,7 +152,7 @@ fun NoteDetailsScreen(
                                 tint = Color.White
                             )
                         },
-                        onClick = { viewModel.updateNote(noteTitle, noteContent) },
+                        onClick = { viewModel.updateNote(titleText.trim(), noteText.trim()) },
                         backgroundColor = MaterialTheme.colors.primary
                     )
                 } else {
@@ -181,17 +161,15 @@ fun NoteDetailsScreen(
             }
         )
 
-        when (val state = updateState.value) {
-            is ViewState.Loading -> LoaderDialog()
-            is ViewState.Success -> navController.navigateUp()
-            is ViewState.Failed -> FailureDialog(state.message)
+        val registerOnStateChanged: @Composable (ViewState<Unit>?) -> Unit = { state ->
+            when (state) {
+                is ViewState.Success -> navController.navigateUp()
+                is ViewState.Failed -> FailureDialog(state.message)
+            }
         }
 
-        when (val state = deleteState.value) {
-            is ViewState.Loading -> LoaderDialog()
-            is ViewState.Success -> navController.navigateUp()
-            is ViewState.Failed -> FailureDialog(state.message)
-        }
+        registerOnStateChanged(updateState.value)
+        registerOnStateChanged(deleteState.value)
     }
 }
 

--- a/noty-android/app/composeapp/src/main/java/dev/shreyaspatil/noty/composeapp/ui/screens/NoteDetailsScreen.kt
+++ b/noty-android/app/composeapp/src/main/java/dev/shreyaspatil/noty/composeapp/ui/screens/NoteDetailsScreen.kt
@@ -57,7 +57,7 @@ import dev.shreyaspatil.noty.composeapp.component.dialog.FailureDialog
 import dev.shreyaspatil.noty.composeapp.component.text.NoteField
 import dev.shreyaspatil.noty.composeapp.component.text.NoteTitleField
 import dev.shreyaspatil.noty.composeapp.utils.ShowToast
-import dev.shreyaspatil.noty.core.view.ViewState
+import dev.shreyaspatil.noty.core.ui.UIDataState
 import dev.shreyaspatil.noty.utils.validator.NoteValidator
 import dev.shreyaspatil.noty.view.viewmodel.NoteDetailViewModel
 import kotlinx.coroutines.ExperimentalCoroutinesApi
@@ -161,10 +161,10 @@ fun NoteDetailsScreen(
             }
         )
 
-        val registerOnStateChanged: @Composable (ViewState<Unit>?) -> Unit = { state ->
+        val registerOnStateChanged: @Composable (UIDataState<Unit>?) -> Unit = { state ->
             when (state) {
-                is ViewState.Success -> navController.navigateUp()
-                is ViewState.Failed -> FailureDialog(state.message)
+                is UIDataState.Success -> navController.navigateUp()
+                is UIDataState.Failed -> FailureDialog(state.message)
             }
         }
 

--- a/noty-android/app/composeapp/src/main/java/dev/shreyaspatil/noty/composeapp/ui/screens/NotesScreen.kt
+++ b/noty-android/app/composeapp/src/main/java/dev/shreyaspatil/noty/composeapp/ui/screens/NotesScreen.kt
@@ -16,6 +16,7 @@
 
 package dev.shreyaspatil.noty.composeapp.ui.screens
 
+import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.material.FloatingActionButton
 import androidx.compose.material.Icon
@@ -26,40 +27,49 @@ import androidx.compose.material.TopAppBar
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Add
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalLifecycleOwner
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.lifecycleScope
 import androidx.navigation.NavHostController
+import com.google.accompanist.swiperefresh.SwipeRefresh
+import com.google.accompanist.swiperefresh.rememberSwipeRefreshState
 import dev.shreyaspatil.noty.composeapp.component.NotesList
 import dev.shreyaspatil.noty.composeapp.component.action.AboutAction
 import dev.shreyaspatil.noty.composeapp.component.action.LogoutAction
 import dev.shreyaspatil.noty.composeapp.component.action.ThemeSwitchAction
 import dev.shreyaspatil.noty.composeapp.component.dialog.FailureDialog
-import dev.shreyaspatil.noty.composeapp.component.dialog.LoaderDialog
+import dev.shreyaspatil.noty.composeapp.ui.MainActivity
 import dev.shreyaspatil.noty.composeapp.ui.Screen
-import dev.shreyaspatil.noty.core.model.Note
 import dev.shreyaspatil.noty.core.view.ViewState
 import dev.shreyaspatil.noty.view.viewmodel.NotesViewModel
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.InternalCoroutinesApi
 import kotlinx.coroutines.launch
 
+@InternalCoroutinesApi
 @ExperimentalCoroutinesApi
 @Composable
-fun NotesScreen(
-    toggleTheme: () -> Unit,
-    navController: NavHostController,
-    viewModel: NotesViewModel
-) {
+fun NotesScreen(navController: NavHostController, viewModel: NotesViewModel) {
     if (!viewModel.isUserLoggedIn()) {
         navigateToLogin(navController)
         return
     }
 
     val lifecycleScope = LocalLifecycleOwner.current.lifecycleScope
+
+    val currentActivity = LocalContext.current as MainActivity
+    val darkMode by currentActivity.preferenceManager.uiModeFlow.collectAsState(initial = isSystemInDarkTheme())
+
+    val switchTheme: () -> Unit = {
+        lifecycleScope.launch { currentActivity.preferenceManager.setDarkMode(!darkMode) }
+    }
 
     Scaffold(
         topBar = {
@@ -76,7 +86,7 @@ fun NotesScreen(
                 contentColor = MaterialTheme.colors.onPrimary,
                 elevation = 0.dp,
                 actions = {
-                    ThemeSwitchAction(toggleTheme)
+                    ThemeSwitchAction(switchTheme)
                     AboutAction {
                         navController.navigate(
                             Screen.About.route
@@ -94,20 +104,24 @@ fun NotesScreen(
             )
         },
         content = {
-            val notesState = viewModel.notes.collectAsState(initial = null).value
+            val notesState = viewModel.notes.collectAsState(initial = ViewState.loading()).value
+            val syncState = viewModel.syncState.collectAsState(initial = ViewState.loading()).value
 
-            val onNoteClicked: (Note) -> Unit = {
-                println("Note Clicked")
-                navController.navigate(Screen.NotesDetail.route(it.id))
+            val isRefreshing = (notesState is ViewState.Loading) or (syncState is ViewState.Loading)
+
+            SwipeRefresh(
+                state = rememberSwipeRefreshState(isRefreshing),
+                onRefresh = { viewModel.syncNotes() }
+            ) {
+                when (notesState) {
+                    is ViewState.Success -> NotesList(notesState.data) { note ->
+                        navController.navigate(Screen.NotesDetail.route(note.id))
+                    }
+                    is ViewState.Failed -> FailureDialog(notesState.message)
+                }
             }
 
-            when (notesState) {
-                is ViewState.Loading, null -> LoaderDialog()
-                is ViewState.Success -> NotesList(notesState.data, onNoteClicked)
-                is ViewState.Failed -> FailureDialog(notesState.message)
-            }
-
-            viewModel.syncNotes()
+            LaunchedEffect(true) { viewModel.syncNotes() }
         },
         floatingActionButton = {
             FloatingActionButton(

--- a/noty-android/app/composeapp/src/main/java/dev/shreyaspatil/noty/composeapp/ui/screens/NotesScreen.kt
+++ b/noty-android/app/composeapp/src/main/java/dev/shreyaspatil/noty/composeapp/ui/screens/NotesScreen.kt
@@ -48,7 +48,7 @@ import dev.shreyaspatil.noty.composeapp.component.action.LogoutAction
 import dev.shreyaspatil.noty.composeapp.component.action.ThemeSwitchAction
 import dev.shreyaspatil.noty.composeapp.component.dialog.FailureDialog
 import dev.shreyaspatil.noty.composeapp.ui.Screen
-import dev.shreyaspatil.noty.core.view.ViewState
+import dev.shreyaspatil.noty.core.ui.UIDataState
 import dev.shreyaspatil.noty.view.viewmodel.NotesViewModel
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.InternalCoroutinesApi
@@ -103,24 +103,24 @@ fun NotesScreen(navController: NavHostController, viewModel: NotesViewModel) {
         content = {
             var isSynced by rememberSaveable { mutableStateOf(false) }
 
-            val notesState = viewModel.notes.collectAsState(initial = ViewState.loading()).value
-            val syncState = viewModel.syncState.collectAsState(initial = ViewState.loading()).value
+            val notesState = viewModel.notes.collectAsState(initial = UIDataState.loading()).value
+            val syncState = viewModel.syncState.collectAsState(initial = UIDataState.loading()).value
 
             // Check whether it's already synced in the past composition
             // Or also check whether current state is also successful or not
-            isSynced = isSynced || syncState is ViewState.Success
+            isSynced = isSynced || syncState is UIDataState.Success
 
-            val isRefreshing = (notesState is ViewState.Loading) or (syncState is ViewState.Loading)
+            val isRefreshing = (notesState is UIDataState.Loading) or (syncState is UIDataState.Loading)
 
             SwipeRefresh(
                 state = rememberSwipeRefreshState(isRefreshing),
                 onRefresh = { viewModel.syncNotes() }
             ) {
                 when (notesState) {
-                    is ViewState.Success -> NotesList(notesState.data) { note ->
+                    is UIDataState.Success -> NotesList(notesState.data) { note ->
                         navController.navigate(Screen.NotesDetail.route(note.id))
                     }
-                    is ViewState.Failed -> FailureDialog(notesState.message)
+                    is UIDataState.Failed -> FailureDialog(notesState.message)
                 }
             }
 

--- a/noty-android/app/composeapp/src/main/java/dev/shreyaspatil/noty/composeapp/ui/screens/NotesScreen.kt
+++ b/noty-android/app/composeapp/src/main/java/dev/shreyaspatil/noty/composeapp/ui/screens/NotesScreen.kt
@@ -31,6 +31,9 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.saveable.rememberSaveable
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalContext
@@ -108,8 +111,14 @@ fun NotesScreen(navController: NavHostController, viewModel: NotesViewModel) {
             )
         },
         content = {
+            var isSynced by rememberSaveable { mutableStateOf(false) }
+
             val notesState = viewModel.notes.collectAsState(initial = ViewState.loading()).value
             val syncState = viewModel.syncState.collectAsState(initial = ViewState.loading()).value
+
+            // Check whether it's already synced in the past composition
+            // Or also check whether current state is also successful or not
+            isSynced = isSynced || syncState is ViewState.Success
 
             val isRefreshing = (notesState is ViewState.Loading) or (syncState is ViewState.Loading)
 
@@ -125,7 +134,11 @@ fun NotesScreen(navController: NavHostController, viewModel: NotesViewModel) {
                 }
             }
 
-            LaunchedEffect(true) { viewModel.syncNotes() }
+            LaunchedEffect(true) {
+                if (!isSynced) {
+                    viewModel.syncNotes()
+                }
+            }
         },
         floatingActionButton = {
             FloatingActionButton(

--- a/noty-android/app/composeapp/src/main/java/dev/shreyaspatil/noty/composeapp/ui/screens/NotesScreen.kt
+++ b/noty-android/app/composeapp/src/main/java/dev/shreyaspatil/noty/composeapp/ui/screens/NotesScreen.kt
@@ -16,6 +16,7 @@
 
 package dev.shreyaspatil.noty.composeapp.ui.screens
 
+import androidx.compose.animation.ExperimentalAnimationApi
 import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.material.FloatingActionButton
@@ -53,6 +54,7 @@ import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.InternalCoroutinesApi
 import kotlinx.coroutines.launch
 
+@ExperimentalAnimationApi
 @InternalCoroutinesApi
 @ExperimentalCoroutinesApi
 @Composable

--- a/noty-android/app/composeapp/src/main/java/dev/shreyaspatil/noty/composeapp/ui/screens/NotesScreen.kt
+++ b/noty-android/app/composeapp/src/main/java/dev/shreyaspatil/noty/composeapp/ui/screens/NotesScreen.kt
@@ -103,24 +103,24 @@ fun NotesScreen(navController: NavHostController, viewModel: NotesViewModel) {
         content = {
             var isSynced by rememberSaveable { mutableStateOf(false) }
 
-            val notesState = viewModel.notes.collectAsState(initial = UIDataState.loading()).value
-            val syncState = viewModel.syncState.collectAsState(initial = UIDataState.loading()).value
+            val notes = viewModel.notes.collectAsState(UIDataState.loading()).value
+            val syncState = viewModel.syncState.collectAsState(UIDataState.loading()).value
 
             // Check whether it's already synced in the past composition
             // Or also check whether current state is also successful or not
             isSynced = isSynced || syncState is UIDataState.Success
 
-            val isRefreshing = (notesState is UIDataState.Loading) or (syncState is UIDataState.Loading)
+            val isRefreshing = (notes is UIDataState.Loading) or (syncState is UIDataState.Loading)
 
             SwipeRefresh(
                 state = rememberSwipeRefreshState(isRefreshing),
                 onRefresh = { viewModel.syncNotes() }
             ) {
-                when (notesState) {
-                    is UIDataState.Success -> NotesList(notesState.data) { note ->
+                when (notes) {
+                    is UIDataState.Success -> NotesList(notes.data) { note ->
                         navController.navigate(Screen.NotesDetail.route(note.id))
                     }
-                    is UIDataState.Failed -> FailureDialog(notesState.message)
+                    is UIDataState.Failed -> FailureDialog(notes.message)
                 }
             }
 

--- a/noty-android/app/composeapp/src/main/java/dev/shreyaspatil/noty/composeapp/ui/screens/NotesScreen.kt
+++ b/noty-android/app/composeapp/src/main/java/dev/shreyaspatil/noty/composeapp/ui/screens/NotesScreen.kt
@@ -32,15 +32,13 @@ import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.platform.LocalContext
-import androidx.compose.ui.platform.LocalLifecycleOwner
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
-import androidx.lifecycle.lifecycleScope
 import androidx.navigation.NavHostController
 import com.google.accompanist.swiperefresh.SwipeRefresh
 import com.google.accompanist.swiperefresh.rememberSwipeRefreshState
@@ -49,7 +47,6 @@ import dev.shreyaspatil.noty.composeapp.component.action.AboutAction
 import dev.shreyaspatil.noty.composeapp.component.action.LogoutAction
 import dev.shreyaspatil.noty.composeapp.component.action.ThemeSwitchAction
 import dev.shreyaspatil.noty.composeapp.component.dialog.FailureDialog
-import dev.shreyaspatil.noty.composeapp.ui.MainActivity
 import dev.shreyaspatil.noty.composeapp.ui.Screen
 import dev.shreyaspatil.noty.core.view.ViewState
 import dev.shreyaspatil.noty.view.viewmodel.NotesViewModel
@@ -67,16 +64,9 @@ fun NotesScreen(navController: NavHostController, viewModel: NotesViewModel) {
         return
     }
 
-    val lifecycleScope = LocalLifecycleOwner.current.lifecycleScope
+    val scope = rememberCoroutineScope()
 
-    val currentActivity = LocalContext.current as MainActivity
-    val darkMode by currentActivity.preferenceManager
-        .uiModeFlow
-        .collectAsState(isSystemInDarkTheme())
-
-    val switchTheme: () -> Unit = {
-        lifecycleScope.launch { currentActivity.preferenceManager.setDarkMode(!darkMode) }
-    }
+    val isInDarkMode = isSystemInDarkTheme()
 
     Scaffold(
         topBar = {
@@ -93,7 +83,7 @@ fun NotesScreen(navController: NavHostController, viewModel: NotesViewModel) {
                 contentColor = MaterialTheme.colors.onPrimary,
                 elevation = 0.dp,
                 actions = {
-                    ThemeSwitchAction(switchTheme)
+                    ThemeSwitchAction { viewModel.setDarkMode(!isInDarkMode) }
                     AboutAction {
                         navController.navigate(
                             Screen.About.route
@@ -101,7 +91,7 @@ fun NotesScreen(navController: NavHostController, viewModel: NotesViewModel) {
                     }
                     LogoutAction(
                         onLogout = {
-                            lifecycleScope.launch {
+                            scope.launch {
                                 viewModel.clearUserSession()
                                 navigateToLogin(navController)
                             }

--- a/noty-android/app/composeapp/src/main/java/dev/shreyaspatil/noty/composeapp/ui/screens/NotesScreen.kt
+++ b/noty-android/app/composeapp/src/main/java/dev/shreyaspatil/noty/composeapp/ui/screens/NotesScreen.kt
@@ -65,7 +65,9 @@ fun NotesScreen(navController: NavHostController, viewModel: NotesViewModel) {
     val lifecycleScope = LocalLifecycleOwner.current.lifecycleScope
 
     val currentActivity = LocalContext.current as MainActivity
-    val darkMode by currentActivity.preferenceManager.uiModeFlow.collectAsState(initial = isSystemInDarkTheme())
+    val darkMode by currentActivity.preferenceManager
+        .uiModeFlow
+        .collectAsState(isSystemInDarkTheme())
 
     val switchTheme: () -> Unit = {
         lifecycleScope.launch { currentActivity.preferenceManager.setDarkMode(!darkMode) }

--- a/noty-android/app/composeapp/src/main/java/dev/shreyaspatil/noty/composeapp/ui/screens/SignUpScreen.kt
+++ b/noty-android/app/composeapp/src/main/java/dev/shreyaspatil/noty/composeapp/ui/screens/SignUpScreen.kt
@@ -48,7 +48,7 @@ import dev.shreyaspatil.noty.composeapp.component.text.UsernameTextField
 import dev.shreyaspatil.noty.composeapp.navigation.NOTY_NAV_HOST_ROUTE
 import dev.shreyaspatil.noty.composeapp.ui.Screen
 import dev.shreyaspatil.noty.composeapp.ui.theme.typography
-import dev.shreyaspatil.noty.core.view.ViewState
+import dev.shreyaspatil.noty.core.ui.UIDataState
 import dev.shreyaspatil.noty.view.viewmodel.RegisterViewModel
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 
@@ -62,8 +62,8 @@ fun SignUpScreen(
     val viewState = viewModel.authFlow.collectAsState(initial = null).value
 
     when (viewState) {
-        is ViewState.Loading -> LoaderDialog()
-        is ViewState.Success -> {
+        is UIDataState.Loading -> LoaderDialog()
+        is UIDataState.Success -> {
             navController.navigate(
                 route = Screen.Notes.route,
                 builder = {
@@ -72,7 +72,7 @@ fun SignUpScreen(
                 }
             )
         }
-        is ViewState.Failed -> FailureDialog(viewState.message)
+        is UIDataState.Failed -> FailureDialog(viewState.message)
     }
 
     LazyColumn {

--- a/noty-android/app/composeapp/src/main/java/dev/shreyaspatil/noty/composeapp/ui/screens/SignUpScreen.kt
+++ b/noty-android/app/composeapp/src/main/java/dev/shreyaspatil/noty/composeapp/ui/screens/SignUpScreen.kt
@@ -24,13 +24,8 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.material.Button
-import androidx.compose.material.Icon
 import androidx.compose.material.MaterialTheme
 import androidx.compose.material.Text
-import androidx.compose.material.TextField
-import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.outlined.Lock
-import androidx.compose.material.icons.outlined.Person
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
@@ -40,21 +35,20 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.SpanStyle
-import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.buildAnnotatedString
-import androidx.compose.ui.text.input.PasswordVisualTransformation
-import androidx.compose.ui.text.input.TextFieldValue
 import androidx.compose.ui.unit.dp
-import androidx.compose.ui.unit.sp
 import androidx.constraintlayout.compose.ConstraintLayout
 import androidx.navigation.NavHostController
 import dev.shreyaspatil.noty.composeapp.component.dialog.FailureDialog
 import dev.shreyaspatil.noty.composeapp.component.dialog.LoaderDialog
+import dev.shreyaspatil.noty.composeapp.component.text.ConfirmPasswordTextField
+import dev.shreyaspatil.noty.composeapp.component.text.PasswordTextField
+import dev.shreyaspatil.noty.composeapp.component.text.TextFieldValue.Valid
+import dev.shreyaspatil.noty.composeapp.component.text.UsernameTextField
 import dev.shreyaspatil.noty.composeapp.navigation.NOTY_NAV_HOST_ROUTE
 import dev.shreyaspatil.noty.composeapp.ui.Screen
 import dev.shreyaspatil.noty.composeapp.ui.theme.typography
 import dev.shreyaspatil.noty.core.view.ViewState
-import dev.shreyaspatil.noty.utils.validator.AuthValidator
 import dev.shreyaspatil.noty.view.viewmodel.RegisterViewModel
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 
@@ -107,84 +101,65 @@ fun SignUpScreen(
                     }
                 )
 
-                var username by remember { mutableStateOf(TextFieldValue()) }
-                val isValidUsername = AuthValidator.isValidUsername(username.text)
+                var username by remember { mutableStateOf("") }
+                var isValidUsername by remember { mutableStateOf(false) }
 
-                TextField(
+                UsernameTextField(
                     modifier = Modifier
                         .fillMaxWidth()
                         .padding(16.dp, 0.dp, 16.dp, 0.dp)
                         .constrainAs(usernameRef) {
-                            top.linkTo(titleRef.bottom, margin = 50.dp)
-                        }.background(MaterialTheme.colors.background),
-                    label = { Text(text = "Username") },
-                    leadingIcon = { Icon(Icons.Outlined.Person, "Person") },
-                    textStyle = TextStyle(
-                        color = MaterialTheme.colors.onPrimary,
-                        fontSize = 16.sp
-                    ),
+                            top.linkTo(titleRef.bottom, margin = 30.dp)
+                        }
+                        .background(MaterialTheme.colors.background),
                     value = username,
-                    onValueChange = {
-                        username = it
-                    },
-                    isError = !isValidUsername
+                    onTextChange = {
+                        username = it.data
+                        isValidUsername = it is Valid
+                    }
                 )
 
-                var password by remember { mutableStateOf(TextFieldValue()) }
-                val isValidPassword = AuthValidator.isValidPassword(password.text)
+                var password by remember { mutableStateOf("") }
+                var isValidPassword by remember { mutableStateOf(false) }
 
-                TextField(
+                PasswordTextField(
                     modifier = Modifier
                         .fillMaxWidth()
                         .padding(16.dp, 0.dp, 16.dp, 0.dp)
                         .constrainAs(passwordRef) {
                             top.linkTo(usernameRef.bottom, margin = 16.dp)
-                        }.background(MaterialTheme.colors.background),
-                    label = { Text(text = "Password") },
-                    leadingIcon = { Icon(Icons.Outlined.Lock, "Lock") },
-                    textStyle = TextStyle(
-                        color = MaterialTheme.colors.onPrimary,
-                        fontSize = 16.sp
-                    ),
-                    visualTransformation = PasswordVisualTransformation(),
+                        }
+                        .background(MaterialTheme.colors.background),
                     value = password,
-                    onValueChange = {
-                        password = it
-                    },
-                    isError = !isValidPassword
+                    onTextChange = {
+                        password = it.data
+                        isValidPassword = it is Valid
+                    }
                 )
 
-                var confirmPassword by remember { mutableStateOf(TextFieldValue()) }
-                val isValidConfirmPassword = AuthValidator.isPasswordAndConfirmPasswordSame(
-                    password.text,
-                    confirmPassword.text
-                )
+                var confirmPassword by remember { mutableStateOf("") }
+                var isValidConfirmPassword by remember { mutableStateOf(false) }
 
-                TextField(
+                ConfirmPasswordTextField(
                     modifier = Modifier
                         .fillMaxWidth()
                         .padding(16.dp, 0.dp, 16.dp, 0.dp)
                         .constrainAs(confirmPasswordRef) {
                             top.linkTo(passwordRef.bottom, margin = 16.dp)
-                        }.background(MaterialTheme.colors.background),
-                    label = { Text(text = "Confirm password") },
-                    leadingIcon = { Icon(Icons.Outlined.Lock, "Lock") },
-                    textStyle = TextStyle(
-                        color = MaterialTheme.colors.onPrimary,
-                        fontSize = 16.sp
-                    ),
-                    visualTransformation = PasswordVisualTransformation(),
+                        }
+                        .background(MaterialTheme.colors.background),
                     value = confirmPassword,
-                    onValueChange = {
-                        confirmPassword = it
-                    },
-                    isError = !isValidConfirmPassword
+                    expectedValue = password,
+                    onTextChange = {
+                        confirmPassword = it.data
+                        isValidConfirmPassword = it is Valid
+                    }
                 )
 
                 Button(
                     onClick = {
                         if (isValidUsername && isValidPassword && isValidConfirmPassword) {
-                            viewModel.register(username.text, password.text)
+                            viewModel.register(username, password)
                         }
                     },
                     modifier = Modifier

--- a/noty-android/app/composeapp/src/main/java/dev/shreyaspatil/noty/composeapp/ui/theme/Color.kt
+++ b/noty-android/app/composeapp/src/main/java/dev/shreyaspatil/noty/composeapp/ui/theme/Color.kt
@@ -16,19 +16,20 @@
 
 package dev.shreyaspatil.noty.composeapp.ui.theme
 
+import androidx.compose.foundation.isSystemInDarkTheme
+import androidx.compose.runtime.Composable
 import androidx.compose.ui.graphics.Color
 
-// primary color
 val primary = Color(0xFF7885FF)
 
-// for bg
-val bgDay = Color(0xfff3f7f9)
-val bgNight = Color(0xff121212)
+val backgroundDay = Color(0xfff3f7f9)
+val backgroundNight = Color(0xff1A191E)
 
-// for card colors
-val day = Color(0xffffffff)
-val night = Color(0xff1A191E)
+val surfaceDay = Color(0xffffffff)
+val surfaceNight = Color(0xFF38353F)
 
-// for text colors
 val black = Color(0xff000000)
 val white = Color(0xffffffff)
+
+@Composable
+fun getTextFieldHintColor(): Color = if (isSystemInDarkTheme()) Color.LightGray else Color.Gray

--- a/noty-android/app/composeapp/src/main/java/dev/shreyaspatil/noty/composeapp/ui/theme/Theme.kt
+++ b/noty-android/app/composeapp/src/main/java/dev/shreyaspatil/noty/composeapp/ui/theme/Theme.kt
@@ -25,8 +25,8 @@ import androidx.compose.runtime.Composable
 private val DarkColorPalette = darkColors(
     primary = primary,
     primaryVariant = primary,
-    background = bgNight,
-    surface = night,
+    background = backgroundNight,
+    surface = surfaceNight,
     onBackground = white,
     onPrimary = white
 )
@@ -34,19 +34,15 @@ private val DarkColorPalette = darkColors(
 private val LightColorPalette = lightColors(
     primary = primary,
     primaryVariant = primary,
-    background = bgDay,
-    surface = day,
+    background = backgroundDay,
+    surface = surfaceDay,
     onBackground = black,
     onPrimary = black
 )
 
 @Composable
 fun NotyTheme(darkTheme: Boolean = isSystemInDarkTheme(), content: @Composable() () -> Unit) {
-    val colors = if (darkTheme) {
-        DarkColorPalette
-    } else {
-        LightColorPalette
-    }
+    val colors = if (darkTheme) DarkColorPalette else LightColorPalette
 
     MaterialTheme(
         colors = colors,

--- a/noty-android/app/composeapp/src/main/java/dev/shreyaspatil/noty/composeapp/utils/AssistedViewModelUtils.kt
+++ b/noty-android/app/composeapp/src/main/java/dev/shreyaspatil/noty/composeapp/utils/AssistedViewModelUtils.kt
@@ -17,6 +17,7 @@
 package dev.shreyaspatil.noty.composeapp.utils
 
 import android.app.Activity
+import androidx.compose.animation.ExperimentalAnimationApi
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.platform.LocalContext
 import androidx.lifecycle.ViewModel
@@ -29,6 +30,7 @@ import dev.shreyaspatil.noty.composeapp.ui.MainActivity
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.InternalCoroutinesApi
 
+@ExperimentalAnimationApi
 @ExperimentalCoroutinesApi
 @InternalCoroutinesApi
 @Composable
@@ -42,6 +44,7 @@ inline fun <reified VM : ViewModel> assistedViewModel(
     return viewModel(viewModelStoreOwner, factory = factory)
 }
 
+@ExperimentalAnimationApi
 @ExperimentalCoroutinesApi
 @InternalCoroutinesApi
 @Composable

--- a/noty-android/app/composeapp/src/main/java/dev/shreyaspatil/noty/composeapp/view/screen/LoginScreen.kt
+++ b/noty-android/app/composeapp/src/main/java/dev/shreyaspatil/noty/composeapp/view/screen/LoginScreen.kt
@@ -26,13 +26,8 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.sizeIn
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.material.Button
-import androidx.compose.material.Icon
 import androidx.compose.material.MaterialTheme
 import androidx.compose.material.Text
-import androidx.compose.material.TextField
-import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.outlined.Lock
-import androidx.compose.material.icons.outlined.Person
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
@@ -44,20 +39,19 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.text.SpanStyle
-import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.buildAnnotatedString
-import androidx.compose.ui.text.input.PasswordVisualTransformation
 import androidx.compose.ui.unit.dp
-import androidx.compose.ui.unit.sp
 import androidx.constraintlayout.compose.ConstraintLayout
 import androidx.navigation.NavHostController
 import dev.shreyaspatil.noty.composeapp.R.drawable.noty_app_logo
 import dev.shreyaspatil.noty.composeapp.component.dialog.FailureDialog
 import dev.shreyaspatil.noty.composeapp.component.dialog.LoaderDialog
+import dev.shreyaspatil.noty.composeapp.component.text.PasswordTextField
+import dev.shreyaspatil.noty.composeapp.component.text.TextFieldValue
+import dev.shreyaspatil.noty.composeapp.component.text.UsernameTextField
 import dev.shreyaspatil.noty.composeapp.ui.Screen
 import dev.shreyaspatil.noty.composeapp.ui.theme.typography
 import dev.shreyaspatil.noty.core.view.ViewState
-import dev.shreyaspatil.noty.utils.validator.AuthValidator
 import dev.shreyaspatil.noty.view.viewmodel.LoginViewModel
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 
@@ -116,8 +110,9 @@ fun LoginScreen(navController: NavHostController, loginViewModel: LoginViewModel
                     }
                 )
                 var username by remember { mutableStateOf("") }
-                val isValidUsername = AuthValidator.isValidUsername(username)
-                TextField(
+                var isValidUsername by remember { mutableStateOf(false) }
+
+                UsernameTextField(
                     modifier = Modifier
                         .fillMaxWidth()
                         .padding(16.dp, 0.dp, 16.dp, 0.dp)
@@ -125,23 +120,17 @@ fun LoginScreen(navController: NavHostController, loginViewModel: LoginViewModel
                             top.linkTo(titleRef.bottom, margin = 30.dp)
                         }
                         .background(MaterialTheme.colors.background),
-                    label = { Text(text = "Username") },
-                    leadingIcon = { Icon(Icons.Outlined.Person, "User") },
-                    textStyle = TextStyle(
-                        color = MaterialTheme.colors.onPrimary,
-                        fontSize = 16.sp
-                    ),
                     value = username,
-                    onValueChange = {
-                        username = it
-                    },
-                    isError = !isValidUsername
+                    onTextChange = {
+                        username = it.data
+                        isValidUsername = it is TextFieldValue.Valid
+                    }
                 )
 
                 var password by remember { mutableStateOf("") }
-                val isValidPassword = AuthValidator.isValidPassword(password)
+                var isValidPassword by remember { mutableStateOf(false) }
 
-                TextField(
+                PasswordTextField(
                     modifier = Modifier
                         .fillMaxWidth()
                         .padding(16.dp, 0.dp, 16.dp, 0.dp)
@@ -149,18 +138,11 @@ fun LoginScreen(navController: NavHostController, loginViewModel: LoginViewModel
                             top.linkTo(usernameRef.bottom, margin = 16.dp)
                         }
                         .background(MaterialTheme.colors.background),
-                    label = { Text(text = "Password") },
-                    leadingIcon = { Icon(Icons.Outlined.Lock, "Password") },
-                    textStyle = TextStyle(
-                        color = MaterialTheme.colors.onPrimary,
-                        fontSize = 16.sp
-                    ),
-                    visualTransformation = PasswordVisualTransformation(),
                     value = password,
-                    onValueChange = {
-                        password = it
-                    },
-                    isError = !isValidPassword
+                    onTextChange = {
+                        password = it.data
+                        isValidPassword = it is TextFieldValue.Valid
+                    }
                 )
 
                 Button(

--- a/noty-android/app/composeapp/src/main/java/dev/shreyaspatil/noty/composeapp/view/screen/LoginScreen.kt
+++ b/noty-android/app/composeapp/src/main/java/dev/shreyaspatil/noty/composeapp/view/screen/LoginScreen.kt
@@ -51,7 +51,7 @@ import dev.shreyaspatil.noty.composeapp.component.text.TextFieldValue
 import dev.shreyaspatil.noty.composeapp.component.text.UsernameTextField
 import dev.shreyaspatil.noty.composeapp.ui.Screen
 import dev.shreyaspatil.noty.composeapp.ui.theme.typography
-import dev.shreyaspatil.noty.core.view.ViewState
+import dev.shreyaspatil.noty.core.ui.UIDataState
 import dev.shreyaspatil.noty.view.viewmodel.LoginViewModel
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 
@@ -62,9 +62,9 @@ fun LoginScreen(navController: NavHostController, loginViewModel: LoginViewModel
     val viewState = loginViewModel.authFlow.collectAsState(initial = null).value
 
     when (viewState) {
-        is ViewState.Loading -> LoaderDialog()
-        is ViewState.Failed -> FailureDialog(viewState.message)
-        is ViewState.Success -> {
+        is UIDataState.Loading -> LoaderDialog()
+        is UIDataState.Failed -> FailureDialog(viewState.message)
+        is UIDataState.Success -> {
             navController.navigate(Screen.Notes.route) {
                 launchSingleTop = true
                 popUpTo(Screen.Login.route) { inclusive = true }

--- a/noty-android/app/simpleapp/src/main/java/dev/shreyaspatil/noty/simpleapp/view/add/AddNoteFragment.kt
+++ b/noty-android/app/simpleapp/src/main/java/dev/shreyaspatil/noty/simpleapp/view/add/AddNoteFragment.kt
@@ -24,7 +24,7 @@ import androidx.core.widget.addTextChangedListener
 import androidx.lifecycle.asLiveData
 import androidx.navigation.fragment.findNavController
 import dagger.hilt.android.AndroidEntryPoint
-import dev.shreyaspatil.noty.core.view.ViewState
+import dev.shreyaspatil.noty.core.ui.UIDataState
 import dev.shreyaspatil.noty.simpleapp.databinding.AddNoteFragmentBinding
 import dev.shreyaspatil.noty.simpleapp.view.base.BaseFragment
 import dev.shreyaspatil.noty.simpleapp.view.hiltNotyMainNavGraphViewModels
@@ -81,14 +81,14 @@ class AddNoteFragment : BaseFragment<AddNoteFragmentBinding, AddNoteViewModel>()
     private fun observeAddNoteResult() {
         viewModel.addNoteState.asLiveData().observe(viewLifecycleOwner) { viewState ->
             when (viewState) {
-                is ViewState.Loading -> showProgressDialog()
+                is UIDataState.Loading -> showProgressDialog()
 
-                is ViewState.Success -> {
+                is UIDataState.Success -> {
                     hideProgressDialog()
                     findNavController().navigateUp()
                 }
 
-                is ViewState.Failed -> {
+                is UIDataState.Failed -> {
                     hideProgressDialog()
                     showErrorDialog("Failed to add a note", viewState.message)
                 }

--- a/noty-android/app/simpleapp/src/main/java/dev/shreyaspatil/noty/simpleapp/view/detail/NoteDetailFragment.kt
+++ b/noty-android/app/simpleapp/src/main/java/dev/shreyaspatil/noty/simpleapp/view/detail/NoteDetailFragment.kt
@@ -32,7 +32,7 @@ import androidx.lifecycle.lifecycleScope
 import androidx.navigation.fragment.findNavController
 import androidx.navigation.fragment.navArgs
 import dagger.hilt.android.AndroidEntryPoint
-import dev.shreyaspatil.noty.core.view.ViewState
+import dev.shreyaspatil.noty.core.ui.UIDataState
 import dev.shreyaspatil.noty.simpleapp.R
 import dev.shreyaspatil.noty.simpleapp.databinding.NoteDetailFragmentBinding
 import dev.shreyaspatil.noty.simpleapp.view.base.BaseFragment
@@ -110,12 +110,12 @@ class NoteDetailFragment : BaseFragment<NoteDetailFragmentBinding, NoteDetailVie
     private fun observeNoteUpdate() {
         viewModel.updateNoteState.asLiveData().observe(viewLifecycleOwner) { viewState ->
             when (viewState) {
-                is ViewState.Loading -> showProgressDialog()
-                is ViewState.Success -> {
+                is UIDataState.Loading -> showProgressDialog()
+                is UIDataState.Success -> {
                     hideProgressDialog()
                     findNavController().navigateUp()
                 }
-                is ViewState.Failed -> {
+                is UIDataState.Failed -> {
                     hideProgressDialog()
                     toast("Error: ${viewState.message}")
                 }
@@ -126,12 +126,12 @@ class NoteDetailFragment : BaseFragment<NoteDetailFragmentBinding, NoteDetailVie
     private fun observeNoteDeletion() {
         viewModel.deleteNoteState.asLiveData().observe(viewLifecycleOwner) { viewState ->
             when (viewState) {
-                is ViewState.Loading -> showProgressDialog()
-                is ViewState.Success -> {
+                is UIDataState.Loading -> showProgressDialog()
+                is UIDataState.Success -> {
                     hideProgressDialog()
                     findNavController().navigateUp()
                 }
-                is ViewState.Failed -> hideProgressDialog()
+                is UIDataState.Failed -> hideProgressDialog()
             }
         }
     }

--- a/noty-android/app/simpleapp/src/main/java/dev/shreyaspatil/noty/simpleapp/view/login/LoginFragment.kt
+++ b/noty-android/app/simpleapp/src/main/java/dev/shreyaspatil/noty/simpleapp/view/login/LoginFragment.kt
@@ -23,7 +23,7 @@ import android.view.ViewGroup
 import androidx.lifecycle.asLiveData
 import androidx.navigation.fragment.findNavController
 import dagger.hilt.android.AndroidEntryPoint
-import dev.shreyaspatil.noty.core.view.ViewState
+import dev.shreyaspatil.noty.core.ui.UIDataState
 import dev.shreyaspatil.noty.simpleapp.R
 import dev.shreyaspatil.noty.simpleapp.databinding.LoginFragmentBinding
 import dev.shreyaspatil.noty.simpleapp.view.base.BaseFragment
@@ -47,12 +47,12 @@ class LoginFragment : BaseFragment<LoginFragmentBinding, LoginViewModel>() {
     private fun initData() {
         viewModel.authFlow.asLiveData().observe(viewLifecycleOwner) { viewState ->
             when (viewState) {
-                is ViewState.Loading -> showProgressDialog()
-                is ViewState.Success -> {
+                is UIDataState.Loading -> showProgressDialog()
+                is UIDataState.Success -> {
                     hideProgressDialog()
                     onAuthSuccess()
                 }
-                is ViewState.Failed -> {
+                is UIDataState.Failed -> {
                     hideProgressDialog()
                     showErrorDialog(
                         title = getString(R.string.dialog_title_login_failed),

--- a/noty-android/app/simpleapp/src/main/java/dev/shreyaspatil/noty/simpleapp/view/notes/NotesFragment.kt
+++ b/noty-android/app/simpleapp/src/main/java/dev/shreyaspatil/noty/simpleapp/view/notes/NotesFragment.kt
@@ -27,7 +27,7 @@ import androidx.lifecycle.lifecycleScope
 import androidx.navigation.fragment.findNavController
 import dagger.hilt.android.AndroidEntryPoint
 import dev.shreyaspatil.noty.core.model.Note
-import dev.shreyaspatil.noty.core.view.ViewState
+import dev.shreyaspatil.noty.core.ui.UIDataState
 import dev.shreyaspatil.noty.simpleapp.R
 import dev.shreyaspatil.noty.simpleapp.databinding.NotesFragmentBinding
 import dev.shreyaspatil.noty.simpleapp.view.base.BaseFragment
@@ -93,7 +93,7 @@ class NotesFragment : BaseFragment<NotesFragmentBinding, NotesViewModel>() {
         viewLifecycleOwner.lifecycleScope.launchWhenStarted {
             viewModel.notes.first().let { notesState ->
                 when {
-                    notesState is ViewState.Success -> notesListAdapter.submitList(notesState.data)
+                    notesState is UIDataState.Success -> notesListAdapter.submitList(notesState.data)
                     notesListAdapter.itemCount == 0 -> syncNotes()
                 }
             }
@@ -109,12 +109,12 @@ class NotesFragment : BaseFragment<NotesFragmentBinding, NotesViewModel>() {
     private fun observeNotes() {
         viewModel.notes.asLiveData().observe(viewLifecycleOwner) {
             when (it) {
-                is ViewState.Loading -> binding.swipeRefreshNotes.isRefreshing = true
-                is ViewState.Success -> onNotesLoaded(it.data).also {
+                is UIDataState.Loading -> binding.swipeRefreshNotes.isRefreshing = true
+                is UIDataState.Success -> onNotesLoaded(it.data).also {
                     binding.swipeRefreshNotes.isRefreshing = false
                 }
 
-                is ViewState.Failed -> {
+                is UIDataState.Failed -> {
                     binding.swipeRefreshNotes.isRefreshing = false
                     toast("Error: ${it.message}")
                 }
@@ -125,9 +125,9 @@ class NotesFragment : BaseFragment<NotesFragmentBinding, NotesViewModel>() {
     private fun observeSync() {
         viewModel.syncState.asLiveData().observe(viewLifecycleOwner) {
             when (it) {
-                is ViewState.Loading -> binding.swipeRefreshNotes.isRefreshing = true
-                is ViewState.Success -> binding.swipeRefreshNotes.isRefreshing = false
-                is ViewState.Failed -> {
+                is UIDataState.Loading -> binding.swipeRefreshNotes.isRefreshing = true
+                is UIDataState.Success -> binding.swipeRefreshNotes.isRefreshing = false
+                is UIDataState.Failed -> {
                     binding.swipeRefreshNotes.isRefreshing = false
                     toast("Sync Error: ${it.message}")
                 }
@@ -239,7 +239,7 @@ class NotesFragment : BaseFragment<NotesFragmentBinding, NotesViewModel>() {
     }
 
     private suspend fun shouldSyncNotes() = viewModel.notes.first()
-        .let { state -> state is ViewState.Failed || notesListAdapter.itemCount == 0 }
+        .let { state -> state is UIDataState.Failed || notesListAdapter.itemCount == 0 }
 
     override fun getViewBinding(
         inflater: LayoutInflater,

--- a/noty-android/app/simpleapp/src/main/java/dev/shreyaspatil/noty/simpleapp/view/notes/NotesFragment.kt
+++ b/noty-android/app/simpleapp/src/main/java/dev/shreyaspatil/noty/simpleapp/view/notes/NotesFragment.kt
@@ -19,7 +19,12 @@ package dev.shreyaspatil.noty.simpleapp.view.notes
 import android.animation.Animator
 import android.animation.AnimatorListenerAdapter
 import android.os.Bundle
-import android.view.*
+import android.view.LayoutInflater
+import android.view.Menu
+import android.view.MenuInflater
+import android.view.MenuItem
+import android.view.View
+import android.view.ViewGroup
 import androidx.core.content.ContextCompat
 import androidx.core.content.res.ResourcesCompat
 import androidx.lifecycle.asLiveData
@@ -33,11 +38,12 @@ import dev.shreyaspatil.noty.simpleapp.databinding.NotesFragmentBinding
 import dev.shreyaspatil.noty.simpleapp.view.base.BaseFragment
 import dev.shreyaspatil.noty.simpleapp.view.hiltNotyMainNavGraphViewModels
 import dev.shreyaspatil.noty.simpleapp.view.notes.adapter.NotesListAdapter
-import dev.shreyaspatil.noty.utils.*
+import dev.shreyaspatil.noty.utils.ConnectionState
 import dev.shreyaspatil.noty.utils.ext.hide
 import dev.shreyaspatil.noty.utils.ext.setDrawableLeft
 import dev.shreyaspatil.noty.utils.ext.shareWhileObserved
 import dev.shreyaspatil.noty.utils.ext.show
+import dev.shreyaspatil.noty.utils.observeConnectivityAsFlow
 import dev.shreyaspatil.noty.view.viewmodel.NotesViewModel
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.Flow
@@ -91,9 +97,9 @@ class NotesFragment : BaseFragment<NotesFragmentBinding, NotesViewModel>() {
 
     private fun loadNotes() {
         viewLifecycleOwner.lifecycleScope.launchWhenStarted {
-            viewModel.notes.first().let { notesState ->
+            viewModel.notes.first().let { notes ->
                 when {
-                    notesState is UIDataState.Success -> notesListAdapter.submitList(notesState.data)
+                    notes is UIDataState.Success -> notesListAdapter.submitList(notes.data)
                     notesListAdapter.itemCount == 0 -> syncNotes()
                 }
             }

--- a/noty-android/app/simpleapp/src/main/java/dev/shreyaspatil/noty/simpleapp/view/register/RegisterFragment.kt
+++ b/noty-android/app/simpleapp/src/main/java/dev/shreyaspatil/noty/simpleapp/view/register/RegisterFragment.kt
@@ -23,7 +23,7 @@ import android.view.ViewGroup
 import androidx.lifecycle.asLiveData
 import androidx.navigation.fragment.findNavController
 import dagger.hilt.android.AndroidEntryPoint
-import dev.shreyaspatil.noty.core.view.ViewState
+import dev.shreyaspatil.noty.core.ui.UIDataState
 import dev.shreyaspatil.noty.simpleapp.R
 import dev.shreyaspatil.noty.simpleapp.databinding.RegisterFragmentBinding
 import dev.shreyaspatil.noty.simpleapp.view.base.BaseFragment
@@ -47,12 +47,12 @@ class RegisterFragment : BaseFragment<RegisterFragmentBinding, RegisterViewModel
     private fun initData() {
         viewModel.authFlow.asLiveData().observe(viewLifecycleOwner) { viewState ->
             when (viewState) {
-                is ViewState.Loading -> showProgressDialog()
-                is ViewState.Success -> {
+                is UIDataState.Loading -> showProgressDialog()
+                is UIDataState.Success -> {
                     hideProgressDialog()
                     onAuthSuccess()
                 }
-                is ViewState.Failed -> {
+                is UIDataState.Failed -> {
                     hideProgressDialog()
                     showErrorDialog(
                         title = getString(R.string.dialog_title_signup_failed),

--- a/noty-android/app/src/main/java/dev/shreyaspatil/noty/session/SessionManagerImpl.kt
+++ b/noty-android/app/src/main/java/dev/shreyaspatil/noty/session/SessionManagerImpl.kt
@@ -42,7 +42,7 @@ class SessionManagerImpl(context: Context) : SessionManager {
     override fun getToken(): String? = sharedPreferences.getString(KEY_TOKEN, null)
 
     companion object {
-        const val FILE_NAME = "auth_shared_pref"
-        const val KEY_TOKEN = "auth_token"
+        private const val FILE_NAME = "auth_shared_pref"
+        private const val KEY_TOKEN = "auth_token"
     }
 }

--- a/noty-android/app/src/main/java/dev/shreyaspatil/noty/view/viewmodel/AddNoteViewModel.kt
+++ b/noty-android/app/src/main/java/dev/shreyaspatil/noty/view/viewmodel/AddNoteViewModel.kt
@@ -23,7 +23,7 @@ import dev.shreyaspatil.noty.core.model.NotyTask
 import dev.shreyaspatil.noty.core.repository.NotyNoteRepository
 import dev.shreyaspatil.noty.core.repository.ResponseResult
 import dev.shreyaspatil.noty.core.task.NotyTaskManager
-import dev.shreyaspatil.noty.core.view.ViewState
+import dev.shreyaspatil.noty.core.ui.UIDataState
 import dev.shreyaspatil.noty.di.LocalRepository
 import dev.shreyaspatil.noty.utils.ext.shareWhileObserved
 import kotlinx.coroutines.ExperimentalCoroutinesApi
@@ -41,21 +41,21 @@ class AddNoteViewModel @Inject constructor(
 
     var job: Job? = null
 
-    private val _addNoteState = MutableSharedFlow<ViewState<String>>()
+    private val _addNoteState = MutableSharedFlow<UIDataState<String>>()
     val addNoteState = _addNoteState.shareWhileObserved(viewModelScope)
 
     fun addNote(title: String, note: String) {
         job?.cancel()
         job = viewModelScope.launch {
-            _addNoteState.emit(ViewState.loading())
+            _addNoteState.emit(UIDataState.loading())
 
             val state = when (val result = noteRepository.addNote(title, note)) {
                 is ResponseResult.Success -> {
                     val noteId = result.data
                     scheduleNoteCreate(noteId)
-                    ViewState.success(noteId)
+                    UIDataState.success(noteId)
                 }
-                is ResponseResult.Error -> ViewState.failed(result.message)
+                is ResponseResult.Error -> UIDataState.failed(result.message)
             }
 
             _addNoteState.emit(state)

--- a/noty-android/app/src/main/java/dev/shreyaspatil/noty/view/viewmodel/LoginViewModel.kt
+++ b/noty-android/app/src/main/java/dev/shreyaspatil/noty/view/viewmodel/LoginViewModel.kt
@@ -22,7 +22,7 @@ import dagger.hilt.android.lifecycle.HiltViewModel
 import dev.shreyaspatil.noty.core.repository.NotyUserRepository
 import dev.shreyaspatil.noty.core.repository.ResponseResult
 import dev.shreyaspatil.noty.core.session.SessionManager
-import dev.shreyaspatil.noty.core.view.ViewState
+import dev.shreyaspatil.noty.core.ui.UIDataState
 import dev.shreyaspatil.noty.utils.ext.shareWhileObserved
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.MutableSharedFlow
@@ -37,15 +37,15 @@ class LoginViewModel @Inject constructor(
     private val sessionManager: SessionManager
 ) : ViewModel() {
 
-    private val _authFlow = MutableSharedFlow<ViewState<String>>()
-    val authFlow: SharedFlow<ViewState<String>> = _authFlow.shareWhileObserved(viewModelScope)
+    private val _authFlow = MutableSharedFlow<UIDataState<String>>()
+    val authFlow: SharedFlow<UIDataState<String>> = _authFlow.shareWhileObserved(viewModelScope)
 
     fun login(
         username: String,
         password: String
     ) {
         viewModelScope.launch {
-            _authFlow.emit(ViewState.loading())
+            _authFlow.emit(UIDataState.loading())
 
             val responseState = notyUserRepository.getUserByUsernameAndPassword(username, password)
 
@@ -53,10 +53,10 @@ class LoginViewModel @Inject constructor(
                 is ResponseResult.Success -> {
                     val authCredential = responseState.data
                     saveToken(authCredential.token)
-                    ViewState.success("Authentication Successful")
+                    UIDataState.success("Authentication Successful")
                 }
 
-                is ResponseResult.Error -> ViewState.failed(responseState.message)
+                is ResponseResult.Error -> UIDataState.failed(responseState.message)
             }
 
             _authFlow.emit(viewState)

--- a/noty-android/app/src/main/java/dev/shreyaspatil/noty/view/viewmodel/NoteDetailViewModel.kt
+++ b/noty-android/app/src/main/java/dev/shreyaspatil/noty/view/viewmodel/NoteDetailViewModel.kt
@@ -31,7 +31,7 @@ import dev.shreyaspatil.noty.core.model.NotyTask
 import dev.shreyaspatil.noty.core.repository.NotyNoteRepository
 import dev.shreyaspatil.noty.core.repository.ResponseResult
 import dev.shreyaspatil.noty.core.task.NotyTaskManager
-import dev.shreyaspatil.noty.core.view.ViewState
+import dev.shreyaspatil.noty.core.ui.UIDataState
 import dev.shreyaspatil.noty.di.LocalRepository
 import dev.shreyaspatil.noty.utils.ext.shareWhileObserved
 import kotlinx.coroutines.ExperimentalCoroutinesApi
@@ -60,16 +60,16 @@ class NoteDetailViewModel @AssistedInject constructor(
     private val _note = MutableSharedFlow<Note>()
     val note: SharedFlow<Note> = _note.shareWhileObserved(viewModelScope)
 
-    private val _updateNoteState = MutableSharedFlow<ViewState<Unit>>()
+    private val _updateNoteState = MutableSharedFlow<UIDataState<Unit>>()
     val updateNoteState = _updateNoteState.shareWhileObserved(viewModelScope)
 
-    private val _deleteNoteState = MutableSharedFlow<ViewState<Unit>>()
+    private val _deleteNoteState = MutableSharedFlow<UIDataState<Unit>>()
     val deleteNoteState = _deleteNoteState.shareWhileObserved(viewModelScope)
 
     fun updateNote(title: String, note: String) {
         job?.cancel()
         job = viewModelScope.launch {
-            _updateNoteState.emit(ViewState.loading())
+            _updateNoteState.emit(UIDataState.loading())
 
             val viewState = when (val result = noteRepository.updateNote(noteId, title, note)) {
                 is ResponseResult.Success -> {
@@ -81,9 +81,9 @@ class NoteDetailViewModel @AssistedInject constructor(
                         scheduleNoteUpdate(noteId)
                     }
 
-                    ViewState.success(Unit)
+                    UIDataState.success(Unit)
                 }
-                is ResponseResult.Error -> ViewState.failed(result.message)
+                is ResponseResult.Error -> UIDataState.failed(result.message)
             }
 
             _updateNoteState.emit(viewState)
@@ -93,7 +93,7 @@ class NoteDetailViewModel @AssistedInject constructor(
     fun deleteNote() {
         job?.cancel()
         job = viewModelScope.launch {
-            _updateNoteState.emit(ViewState.loading())
+            _updateNoteState.emit(UIDataState.loading())
 
             val viewState = when (val result = noteRepository.deleteNote(noteId)) {
                 is ResponseResult.Success -> {
@@ -102,9 +102,9 @@ class NoteDetailViewModel @AssistedInject constructor(
                     if (!NotyNoteRepository.isTemporaryNote(noteId)) {
                         scheduleNoteDelete(noteId)
                     }
-                    ViewState.success(Unit)
+                    UIDataState.success(Unit)
                 }
-                is ResponseResult.Error -> ViewState.failed(result.message)
+                is ResponseResult.Error -> UIDataState.failed(result.message)
             }
             _deleteNoteState.emit(viewState)
         }

--- a/noty-android/app/src/main/java/dev/shreyaspatil/noty/view/viewmodel/NotesViewModel.kt
+++ b/noty-android/app/src/main/java/dev/shreyaspatil/noty/view/viewmodel/NotesViewModel.kt
@@ -30,8 +30,18 @@ import dev.shreyaspatil.noty.core.task.TaskState
 import dev.shreyaspatil.noty.core.view.ViewState
 import dev.shreyaspatil.noty.di.LocalRepository
 import dev.shreyaspatil.noty.utils.ext.shareWhileObserved
-import kotlinx.coroutines.*
-import kotlinx.coroutines.flow.*
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.SharedFlow
+import kotlinx.coroutines.flow.collect
+import kotlinx.coroutines.flow.distinctUntilChanged
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.onStart
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
 import javax.inject.Inject
 
 @ExperimentalCoroutinesApi

--- a/noty-android/app/src/main/java/dev/shreyaspatil/noty/view/viewmodel/NotesViewModel.kt
+++ b/noty-android/app/src/main/java/dev/shreyaspatil/noty/view/viewmodel/NotesViewModel.kt
@@ -27,7 +27,7 @@ import dev.shreyaspatil.noty.core.repository.ResponseResult
 import dev.shreyaspatil.noty.core.session.SessionManager
 import dev.shreyaspatil.noty.core.task.NotyTaskManager
 import dev.shreyaspatil.noty.core.task.TaskState
-import dev.shreyaspatil.noty.core.view.ViewState
+import dev.shreyaspatil.noty.core.ui.UIDataState
 import dev.shreyaspatil.noty.di.LocalRepository
 import dev.shreyaspatil.noty.utils.ext.shareWhileObserved
 import kotlinx.coroutines.Dispatchers
@@ -55,17 +55,17 @@ class NotesViewModel @Inject constructor(
 
     private var syncJob: Job? = null
 
-    private val _syncState = MutableSharedFlow<ViewState<Unit>>()
-    val syncState: SharedFlow<ViewState<Unit>> = _syncState.shareWhileObserved(viewModelScope)
+    private val _syncState = MutableSharedFlow<UIDataState<Unit>>()
+    val syncState: SharedFlow<UIDataState<Unit>> = _syncState.shareWhileObserved(viewModelScope)
 
-    val notes: SharedFlow<ViewState<List<Note>>> = notyNoteRepository.getAllNotes()
+    val notes: SharedFlow<UIDataState<List<Note>>> = notyNoteRepository.getAllNotes()
         .distinctUntilChanged()
         .map { result ->
             when (result) {
-                is ResponseResult.Success -> ViewState.success(result.data)
-                is ResponseResult.Error -> ViewState.failed(result.message)
+                is ResponseResult.Success -> UIDataState.success(result.data)
+                is ResponseResult.Error -> UIDataState.failed(result.message)
             }
-        }.onStart { emit(ViewState.loading()) }
+        }.onStart { emit(UIDataState.loading()) }
         .shareWhileObserved(viewModelScope)
 
     fun syncNotes() {
@@ -76,9 +76,9 @@ class NotesViewModel @Inject constructor(
             try {
                 notyTaskManager.observeTask(taskId).collect { taskState ->
                     val viewState = when (taskState) {
-                        TaskState.SCHEDULED -> ViewState.loading()
-                        TaskState.COMPLETED, TaskState.CANCELLED -> ViewState.success(Unit)
-                        TaskState.FAILED -> ViewState.failed("Failed")
+                        TaskState.SCHEDULED -> UIDataState.loading()
+                        TaskState.COMPLETED, TaskState.CANCELLED -> UIDataState.success(Unit)
+                        TaskState.FAILED -> UIDataState.failed("Failed")
                     }
 
                     _syncState.emit(viewState)

--- a/noty-android/app/src/main/java/dev/shreyaspatil/noty/view/viewmodel/RegisterViewModel.kt
+++ b/noty-android/app/src/main/java/dev/shreyaspatil/noty/view/viewmodel/RegisterViewModel.kt
@@ -22,7 +22,7 @@ import dagger.hilt.android.lifecycle.HiltViewModel
 import dev.shreyaspatil.noty.core.repository.NotyUserRepository
 import dev.shreyaspatil.noty.core.repository.ResponseResult
 import dev.shreyaspatil.noty.core.session.SessionManager
-import dev.shreyaspatil.noty.core.view.ViewState
+import dev.shreyaspatil.noty.core.ui.UIDataState
 import dev.shreyaspatil.noty.utils.ext.shareWhileObserved
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.MutableSharedFlow
@@ -37,15 +37,15 @@ class RegisterViewModel @Inject constructor(
     private val sessionManager: SessionManager
 ) : ViewModel() {
 
-    private val _authFlow = MutableSharedFlow<ViewState<String>>()
-    val authFlow: SharedFlow<ViewState<String>> = _authFlow.shareWhileObserved(viewModelScope)
+    private val _authFlow = MutableSharedFlow<UIDataState<String>>()
+    val authFlow: SharedFlow<UIDataState<String>> = _authFlow.shareWhileObserved(viewModelScope)
 
     fun register(
         username: String,
         password: String
     ) {
         viewModelScope.launch {
-            _authFlow.emit(ViewState.loading())
+            _authFlow.emit(UIDataState.loading())
 
             val responseState = notyUserRepository.addUser(username, password)
 
@@ -53,10 +53,10 @@ class RegisterViewModel @Inject constructor(
                 is ResponseResult.Success -> {
                     val authCredential = responseState.data
                     saveToken(authCredential.token)
-                    ViewState.success("Registration Successful")
+                    UIDataState.success("Registration Successful")
                 }
 
-                is ResponseResult.Error -> ViewState.failed(responseState.message)
+                is ResponseResult.Error -> UIDataState.failed(responseState.message)
             }
 
             _authFlow.emit(viewState)

--- a/noty-android/core/src/main/java/dev/shreyaspatil/noty/core/preference/PreferenceManager.kt
+++ b/noty-android/core/src/main/java/dev/shreyaspatil/noty/core/preference/PreferenceManager.kt
@@ -16,8 +16,8 @@
 
 package dev.shreyaspatil.noty.core.preference
 
-import javax.inject.Singleton
 import kotlinx.coroutines.flow.Flow
+import javax.inject.Singleton
 
 /**
  * Preference Manager for the application.
@@ -25,6 +25,12 @@ import kotlinx.coroutines.flow.Flow
  */
 @Singleton
 interface PreferenceManager {
+    /**
+     * Flow of the UI mode preference
+     *
+     * true - Dark mode enabled
+     * false - Dark mode disabled (i.e. Light mode)
+     */
     val uiModeFlow: Flow<Boolean>
 
     /**

--- a/noty-android/core/src/main/java/dev/shreyaspatil/noty/core/task/NotyTaskManager.kt
+++ b/noty-android/core/src/main/java/dev/shreyaspatil/noty/core/task/NotyTaskManager.kt
@@ -23,10 +23,43 @@ import javax.inject.Singleton
 
 @Singleton
 interface NotyTaskManager {
+    /**
+     * Schedules a task for syncing notes.
+     *
+     * @return Unique work ID
+     */
     fun syncNotes(): UUID
+
+    /**
+     * Schedules a [NotyTask] task
+     *
+     * @return Unique work ID
+     */
     fun scheduleTask(notyTask: NotyTask): UUID
+
+    /**
+     * Retrieves the state of a task
+     *
+     * @param taskId Unique work ID
+     * @return Nullable (in case task not exists) task state
+     */
     fun getTaskState(taskId: UUID): TaskState?
+
+    /**
+     * Returns Flowable task state of a specific task
+     *
+     * @param taskId Unique work ID
+     * @return Flow of task state
+     */
     fun observeTask(taskId: UUID): Flow<TaskState>
+
+    /**
+     * Aborts/Stops all scheduled (ongoing) tasks
+     */
     fun abortAllTasks()
+
+    /**
+     * Generates task ID from note ID
+     */
     fun getTaskIdFromNoteId(noteId: String) = noteId
 }

--- a/noty-android/core/src/main/java/dev/shreyaspatil/noty/core/ui/UIDataState.kt
+++ b/noty-android/core/src/main/java/dev/shreyaspatil/noty/core/ui/UIDataState.kt
@@ -14,15 +14,15 @@
  * limitations under the License.
  */
 
-package dev.shreyaspatil.noty.core.view
+package dev.shreyaspatil.noty.core.ui
 
 /**
  * State for managing UI operations.
  */
-sealed class ViewState<T> {
-    class Loading<T> : ViewState<T>()
-    class Success<T>(val data: T) : ViewState<T>()
-    class Failed<T>(val message: String) : ViewState<T>()
+sealed class UIDataState<T> {
+    class Loading<T> : UIDataState<T>()
+    class Success<T>(val data: T) : UIDataState<T>()
+    class Failed<T>(val message: String) : UIDataState<T>()
 
     companion object {
         fun <T> loading() = Loading<T>()

--- a/noty-android/dependencies.gradle
+++ b/noty-android/dependencies.gradle
@@ -19,7 +19,7 @@ ext {
     androidGradlePluginVersion = '7.0.0'
 
     // Kotlin
-    kotlinVersion = "1.5.10"
+    kotlinVersion = "1.5.21"
     ktlintVersion = "10.1.0"
     coroutinesVersion = "1.5.0"
 
@@ -61,7 +61,7 @@ ext {
     javaxInjectVersion = "1"
 
     // Jetpack Compose
-    composeVersion = "1.0.0"
+    composeVersion = "1.0.1"
 
     // Constrain Layout (Compose)
     composeConstraintLayoutVersion = "1.0.0-beta01"

--- a/noty-android/dependencies.gradle
+++ b/noty-android/dependencies.gradle
@@ -47,7 +47,7 @@ ext {
     lottieComposeVersion = "4.0.0"
 
     // DI
-    daggerHiltVersion = "2.37"
+    daggerHiltVersion = "2.38.1"
     jetpackHiltVersion = "1.0.0"
 
     // Networking

--- a/noty-android/dependencies.gradle
+++ b/noty-android/dependencies.gradle
@@ -74,6 +74,9 @@ ext {
 
     lifecycleViewModelComposeVersion = "1.0.0-alpha07"
 
+    // Accompanist
+    accompanistVersion = "0.15.0"
+
     // Testing
     jUnitVersion = "4.13.2"
     androidJUnitVersion = "1.1.2"

--- a/noty-android/dependencies.gradle
+++ b/noty-android/dependencies.gradle
@@ -34,7 +34,7 @@ ext {
     navigationVersion = "2.3.5"
     securityCryptoVersion = '1.1.0-alpha03'
     roomVersion = "2.3.0"
-    dataStoreVersion = '1.0.0-rc02'
+    dataStoreVersion = '1.0.0'
     legacySupportVersion = "1.0.0"
 
     // Design


### PR DESCRIPTION
# Summary

- Improved User experience for Jetpack Compose Application
- Improved Codebase

## Description of change

- [#118] Added support for Swipe refresh in Notes screen (composeapp)
- [#196] Fixed bug: Avoid re-syncing notes whenever notes screen is re-launched _(after pressing back from any other screen)_. 
- [#197] Improved UI for adding/viewing notes: Improved text input field UI which is now more easy to interact with as compared to earlier.

## Codebase changes

- Bumped Kotlin to 1.5.21 and Jetpack Compose to 1.0.1
- Created common composable components and re-used them throughout the application.
- Refactor: renamed colours of the theme (composeapp)
- Added code documentation for classes _(where docs were not there earlier)_.

## Checklist

<!--
The current CI workflow will validate code level changes. 
Make sure that `./gradlew build` is passing before raising a PR. If build is failing at linting then just 
execute `./gradlew ktlintFormat` which will reformat code according to our code standards.
Other than this, it's encouraged if you pay attention to the below checklist.
-->

- [x] Build and linting is passing.
- [x] This change is not breaking existing flow of a system.
- [ ] I have written test case for this change.
- [x] This change is tested from all aspects.
- [x] Implemented any new third-party library _(Which not existed before this change)_.
