### PR TITLE
Fixes: [compseapp] Reload on config changes / [simpleapp] Minor fixes

### DIFF
--- a/noty-android/app/composeapp/src/main/AndroidManifest.xml
+++ b/noty-android/app/composeapp/src/main/AndroidManifest.xml
@@ -1,5 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
-<!--
+<?xml version="1.0" encoding="utf-8"?><!--
   ~ Copyright 2020 Shreyas Patil
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
@@ -32,6 +31,7 @@
         android:theme="@style/AppTheme">
         <activity
             android:name=".ui.MainActivity"
+            android:configChanges="keyboard|keyboardHidden|orientation|navigation|screenSize|screenLayout"
             android:label="@string/app_name"
             android:theme="@style/AppTheme.Splash">
             <intent-filter>

--- a/noty-android/app/composeapp/src/main/java/dev/shreyaspatil/noty/composeapp/ui/screens/NotesScreen.kt
+++ b/noty-android/app/composeapp/src/main/java/dev/shreyaspatil/noty/composeapp/ui/screens/NotesScreen.kt
@@ -101,20 +101,23 @@ fun NotesScreen(navController: NavHostController, viewModel: NotesViewModel) {
             )
         },
         content = {
-            var isSynced by rememberSaveable { mutableStateOf(false) }
+            var isSynced by rememberSaveable(key = "notesSyncedInitially") { mutableStateOf(false) }
 
             val notes = viewModel.notes.collectAsState(UIDataState.loading()).value
             val syncState = viewModel.syncState.collectAsState(UIDataState.loading()).value
 
             // Check whether it's already synced in the past composition
             // Or also check whether current state is also successful or not
-            isSynced = isSynced || syncState is UIDataState.Success
+            isSynced = isSynced || syncState.isSuccess
 
-            val isRefreshing = (notes is UIDataState.Loading) or (syncState is UIDataState.Loading)
+            val isRefreshing = notes.isLoading or syncState.isLoading
 
             SwipeRefresh(
                 state = rememberSwipeRefreshState(isRefreshing),
-                onRefresh = { viewModel.syncNotes() }
+                onRefresh = {
+                    isSynced = false
+                    viewModel.syncNotes()
+                }
             ) {
                 when (notes) {
                     is UIDataState.Success -> NotesList(notes.data) { note ->

--- a/noty-android/app/simpleapp/src/main/java/dev/shreyaspatil/noty/simpleapp/view/base/BaseFragment.kt
+++ b/noty-android/app/simpleapp/src/main/java/dev/shreyaspatil/noty/simpleapp/view/base/BaseFragment.kt
@@ -25,8 +25,8 @@ import android.widget.Toast
 import androidx.fragment.app.Fragment
 import androidx.lifecycle.ViewModel
 import androidx.viewbinding.ViewBinding
-import dev.shreyaspatil.noty.simpleapp.view.custom.ProgressDialog
 import dev.shreyaspatil.noty.simpleapp.view.custom.ErrorDialog
+import dev.shreyaspatil.noty.simpleapp.view.custom.ProgressDialog
 
 abstract class BaseFragment<VB : ViewBinding, VM : ViewModel> : Fragment() {
 
@@ -79,7 +79,8 @@ abstract class BaseFragment<VB : ViewBinding, VM : ViewModel> : Fragment() {
         Toast.makeText(activity, message, Toast.LENGTH_SHORT).show()
     }
 
-    fun applicationContext(): Context = requireActivity().applicationContext
+    val applicationContext: Context
+        get() = requireContext().applicationContext
 
     override fun onDestroy() {
         super.onDestroy()

--- a/noty-android/app/simpleapp/src/main/java/dev/shreyaspatil/noty/simpleapp/view/base/BaseFragment.kt
+++ b/noty-android/app/simpleapp/src/main/java/dev/shreyaspatil/noty/simpleapp/view/base/BaseFragment.kt
@@ -83,13 +83,14 @@ abstract class BaseFragment<VB : ViewBinding, VM : ViewModel> : Fragment() {
         get() = requireContext().applicationContext
 
     override fun onDestroyView() {
-        super.onDestroyView()
         _binding = null
         progressDialog?.dismiss()
         progressDialog = null
 
         errorDialog?.dismiss()
         errorDialog = null
+
+        super.onDestroyView()
     }
 
     protected abstract fun getViewBinding(inflater: LayoutInflater, container: ViewGroup?): VB

--- a/noty-android/app/simpleapp/src/main/java/dev/shreyaspatil/noty/simpleapp/view/base/BaseFragment.kt
+++ b/noty-android/app/simpleapp/src/main/java/dev/shreyaspatil/noty/simpleapp/view/base/BaseFragment.kt
@@ -82,8 +82,8 @@ abstract class BaseFragment<VB : ViewBinding, VM : ViewModel> : Fragment() {
     val applicationContext: Context
         get() = requireContext().applicationContext
 
-    override fun onDestroy() {
-        super.onDestroy()
+    override fun onDestroyView() {
+        super.onDestroyView()
         _binding = null
         progressDialog?.dismiss()
         progressDialog = null

--- a/noty-android/app/simpleapp/src/main/java/dev/shreyaspatil/noty/simpleapp/view/notes/NotesFragment.kt
+++ b/noty-android/app/simpleapp/src/main/java/dev/shreyaspatil/noty/simpleapp/view/notes/NotesFragment.kt
@@ -279,6 +279,11 @@ class NotesFragment : BaseFragment<NotesFragmentBinding, NotesViewModel>() {
         return super.onOptionsItemSelected(item)
     }
 
+    override fun onDestroyView() {
+        binding.notesRecyclerView.adapter = null
+        super.onDestroyView()
+    }
+
     companion object {
         const val ANIMATION_DURATION = 2000L
     }

--- a/noty-android/app/src/main/java/dev/shreyaspatil/noty/utils/NetworkUtils.kt
+++ b/noty-android/app/src/main/java/dev/shreyaspatil/noty/utils/NetworkUtils.kt
@@ -63,7 +63,8 @@ fun Context.observeConnectivityAsFlow() = callbackFlow {
  */
 val Context.currentConnectivityState: ConnectionState
     get() {
-        val connectivityManager = getSystemService(Context.CONNECTIVITY_SERVICE) as ConnectivityManager
+        val connectivityManager =
+            getSystemService(Context.CONNECTIVITY_SERVICE) as ConnectivityManager
         return getCurrentConnectivityState(connectivityManager)
     }
 

--- a/noty-android/core/src/main/java/dev/shreyaspatil/noty/core/ui/UIDataState.kt
+++ b/noty-android/core/src/main/java/dev/shreyaspatil/noty/core/ui/UIDataState.kt
@@ -17,12 +17,18 @@
 package dev.shreyaspatil.noty.core.ui
 
 /**
- * State for managing UI operations.
+ * State for UI containing data.
  */
 sealed class UIDataState<T> {
     class Loading<T> : UIDataState<T>()
     class Success<T>(val data: T) : UIDataState<T>()
     class Failed<T>(val message: String) : UIDataState<T>()
+
+    val isLoading get() = this is Loading
+
+    val isSuccess get() = this is Success
+
+    val isFailed get() = this is Failed
 
     companion object {
         fun <T> loading() = Loading<T>()


### PR DESCRIPTION
<!--
Thanks for submitting a pull request!

Please make sure you've read and understood our contributing guidelines;
https://github.com/patilshreyas/NotyKT/blob/master/CONTRIBUTING.md

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx", where #xxxx is the issue number.

Please provide enough information so that others can review your pull request.
The first three fields are mandatory:
-->

## Summary

This PR includes changes in the simple app and compose app.

### composeapp

- [#203] Handled configuration changes (such as device orientation, UI mode) in notes screen to avoid re-sync/re-loading notes. 

### simpleapp

- [#206] Fixed memory leak occurred due to `RecyclerView` Adapter in `NotesFragment.kt`
- Earlier, `BaseFragment` was clearing views on `onDestroy()`. Changed it to `onDestroyView()`.

## Checklist

- [x] Build and linting is passing.
- [x] This change is not breaking existing flow of a system.
- [ ] I have written test case for this change.
- [x] This change is tested from all aspects.
- [ ] Implemented any new third-party library _(Which not existed before this change)_.
