### PR TITLE
Fix: remove WorkManager initializer

### DIFF
--- a/noty-android/app/src/main/AndroidManifest.xml
+++ b/noty-android/app/src/main/AndroidManifest.xml
@@ -24,9 +24,16 @@
     <application>
         <!-- Hilt customizes the WorkManager configuration, that's why we must remove the default initializer -->
         <provider
-            android:name="androidx.work.impl.WorkManagerInitializer"
-            android:authorities="${applicationId}.workmanager-init"
-            tools:node="remove" />
+            android:name="androidx.startup.InitializationProvider"
+            android:authorities="${applicationId}.androidx-startup"
+            android:exported="false"
+            tools:node="merge">
+            <!-- If you are using androidx.startup to initialize other components -->
+            <meta-data
+                android:name="androidx.work.WorkManagerInitializer"
+                android:value="androidx.startup"
+                tools:node="remove" />
+        </provider>
     </application>
 
 </manifest>


### PR DESCRIPTION
<!--
Thanks for submitting a pull request!

Please make sure you've read and understood our contributing guidelines;
https://github.com/patilshreyas/NotyKT/blob/master/CONTRIBUTING.md

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx", where #xxxx is the issue number.

Please provide enough information so that others can review your pull request.
The first three fields are mandatory:
-->

## Summary

Remove default `WorkManager` initializer

<!--
Explain the **motivation** for making this change.
What existing problem does the pull request solve?
-->

## Description for the changelog

<!--
Write a short (one line) summary that describes the changes in this
pull request
-->

Since we are using Hilt for injecting `WorkManager`, we need to disable the default initializer of a `WorkManager`. We already did it but in the recent version of _WorkManager (2.7.0)_ it's not coming with the Startup library. So this is handled and fixed in this PR.

## Checklist

<!--
The current CI workflow will validate code level changes. 
Make sure that `./gradlew build` is passing before raising a PR. If build is failing at linting then just 
execute `./gradlew ktlintFormat` which will reformat code according to our code standards.
Other than this, it's encouraged if you pay attention to the below checklist.
-->

- [x] Build and linting is passing.
- [x] This change is not breaking existing flow of a system.
- [ ] I have written test case for this change.
- [x] This change is tested from all aspects.
- [ ] Implemented any new third-party library _(Which not existed before this change)_.
