### PR TITLE
[ComposeApp] Improve touch region area of input fields, Remove focus from fields on sharing image 

### DIFF
--- a/noty-android/app/composeapp/src/main/java/dev/shreyaspatil/noty/composeapp/component/text/CommonTextField.kt
+++ b/noty-android/app/composeapp/src/main/java/dev/shreyaspatil/noty/composeapp/component/text/CommonTextField.kt
@@ -69,7 +69,8 @@ fun BasicNotyTextField(
     label: String = "",
     textStyle: TextStyle = TextStyle(fontSize = 16.sp, fontWeight = FontWeight.Normal),
     onTextChange: (String) -> Unit,
-    maxLines: Int = Int.MAX_VALUE
+    maxLines: Int = Int.MAX_VALUE,
+    textFieldModifier: Modifier = Modifier
 ) {
 
     Box(modifier = modifier.padding(4.dp)) {
@@ -82,7 +83,7 @@ fun BasicNotyTextField(
             )
         }
         BasicTextField(
-            modifier = Modifier.fillMaxWidth(),
+            modifier = textFieldModifier.fillMaxWidth(),
             value = value,
             onValueChange = onTextChange,
             textStyle = textStyle.copy(color = MaterialTheme.colors.onPrimary),

--- a/noty-android/app/composeapp/src/main/java/dev/shreyaspatil/noty/composeapp/component/text/CommonTextField.kt
+++ b/noty-android/app/composeapp/src/main/java/dev/shreyaspatil/noty/composeapp/component/text/CommonTextField.kt
@@ -19,6 +19,7 @@ package dev.shreyaspatil.noty.composeapp.component.text
 import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.animation.ExperimentalAnimationApi
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.text.BasicTextField
 import androidx.compose.material.MaterialTheme
@@ -81,6 +82,7 @@ fun BasicNotyTextField(
             )
         }
         BasicTextField(
+            modifier = Modifier.fillMaxWidth(),
             value = value,
             onValueChange = onTextChange,
             textStyle = textStyle.copy(color = MaterialTheme.colors.onPrimary),

--- a/noty-android/app/composeapp/src/main/java/dev/shreyaspatil/noty/composeapp/ui/screens/NoteDetailsScreen.kt
+++ b/noty-android/app/composeapp/src/main/java/dev/shreyaspatil/noty/composeapp/ui/screens/NoteDetailsScreen.kt
@@ -18,6 +18,7 @@ package dev.shreyaspatil.noty.composeapp.ui.screens
 
 import androidx.compose.animation.ExperimentalAnimationApi
 import androidx.compose.foundation.background
+import androidx.compose.foundation.focusable
 import androidx.compose.foundation.gestures.Orientation
 import androidx.compose.foundation.gestures.scrollable
 import androidx.compose.foundation.layout.Column
@@ -41,6 +42,8 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.focus.FocusRequester
+import androidx.compose.ui.focus.focusRequester
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.painterResource
@@ -75,6 +78,10 @@ fun NoteDetailsScreen(
     navController: NavHostController,
     viewModel: NoteDetailViewModel
 ) {
+
+    val focusRequester = remember {
+        FocusRequester()
+    }
     val context = LocalContext.current
 
     val updateState = viewModel.updateNoteState.collectAsState(initial = null)
@@ -88,6 +95,9 @@ fun NoteDetailsScreen(
         var captureNoteImageRequestKey: Int? by remember { mutableStateOf(null) }
 
         Scaffold(
+            modifier = Modifier
+                .focusRequester(focusRequester)
+                .focusable(true),
             topBar = {
                 TopAppBar(
                     title = {
@@ -134,6 +144,7 @@ fun NoteDetailsScreen(
                                 ShareActionItem(
                                     label = "Image",
                                     onActionClick = {
+                                        focusRequester.requestFocus()
                                         captureNoteImageRequestKey = Random.nextInt(Int.MAX_VALUE)
                                     }
                                 ),


### PR DESCRIPTION
1. Increase touch region area for Input fields
2. Remove focus from fields on share as Image

closes #284 , closes #283

## Checklist

<!--
The current CI workflow will validate code level changes. 
Make sure that `./gradlew build` is passing before raising a PR. If build is failing at linting then just 
execute `./gradlew ktlintFormat` which will reformat code according to our code standards.
Other than this, it's encouraged if you pay attention to the below checklist.
-->

- [x] Build and linting is passing.
- [x] This change is not breaking existing flow of a system.
- [ ] I have written test case for this change.
- [x] This change is tested from all aspects.
- [ ] Implemented any new third-party library _(Which not existed before this change)_.
