### PR TITLE
[ComposeApp] Show confirmation dialogs in the app

### DIFF
--- a/noty-android/app/composeapp/src/main/java/dev/shreyaspatil/noty/composeapp/component/dialog/NotyDialogs.kt
+++ b/noty-android/app/composeapp/src/main/java/dev/shreyaspatil/noty/composeapp/component/dialog/NotyDialogs.kt
@@ -88,7 +88,7 @@ fun FailureDialog(failureMessage: String, onDismissed: () -> Unit = {}) {
                             .height(80.dp)
                             .padding(16.dp),
 
-                        ) {
+                    ) {
                         Text(style = typography.subtitle1, color = Color.White, text = "OK")
                     }
                 }
@@ -147,7 +147,7 @@ fun ConfirmationDialog(
                             modifier = Modifier
                                 .padding(horizontal = 4.dp),
 
-                            ) {
+                        ) {
                             Text(
                                 style = typography.button,
                                 color = MaterialTheme.colors.primary,
@@ -162,7 +162,7 @@ fun ConfirmationDialog(
                             modifier = Modifier
                                 .padding(horizontal = 4.dp),
 
-                            ) {
+                        ) {
                             Text(
                                 style = typography.button,
                                 color = MaterialTheme.colors.primary,

--- a/noty-android/app/composeapp/src/main/java/dev/shreyaspatil/noty/composeapp/component/dialog/NotyDialogs.kt
+++ b/noty-android/app/composeapp/src/main/java/dev/shreyaspatil/noty/composeapp/component/dialog/NotyDialogs.kt
@@ -16,14 +16,23 @@
 
 package dev.shreyaspatil.noty.composeapp.component.dialog
 
-import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
 import androidx.compose.material.Button
 import androidx.compose.material.MaterialTheme
 import androidx.compose.material.Surface
 import androidx.compose.material.Text
+import androidx.compose.material.TextButton
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
@@ -79,8 +88,87 @@ fun FailureDialog(failureMessage: String, onDismissed: () -> Unit = {}) {
                             .height(80.dp)
                             .padding(16.dp),
 
-                    ) {
+                        ) {
                         Text(style = typography.subtitle1, color = Color.White, text = "OK")
+                    }
+                }
+            }
+        }
+    }
+}
+
+@Composable
+fun ConfirmationDialog(
+    title: String,
+    message: String,
+    onConfirmedYes: () -> Unit,
+    onConfirmedNo: () -> Unit,
+    onDismissed: () -> Unit
+) {
+    var isDismissed by remember { mutableStateOf(false) }
+
+    if (!isDismissed) {
+        Dialog(onDismissRequest = {}) {
+            Surface {
+                Column(
+                    horizontalAlignment = Alignment.Start,
+                    modifier = Modifier.padding(
+                        top = 16.dp,
+                        bottom = 8.dp,
+                        start = 16.dp,
+                        end = 16.dp
+                    )
+                ) {
+                    Text(
+                        text = title,
+                        color = MaterialTheme.colors.onSurface,
+                        style = MaterialTheme.typography.body1,
+                        fontWeight = FontWeight.Bold
+                    )
+
+                    Text(
+                        text = message,
+                        color = MaterialTheme.colors.onSurface,
+                        style = MaterialTheme.typography.body2,
+                        fontWeight = FontWeight.Normal,
+                        modifier = Modifier.padding(vertical = 8.dp)
+                    )
+
+                    Row(
+                        modifier = Modifier.fillMaxWidth(),
+                        horizontalArrangement = Arrangement.End,
+                        verticalAlignment = Alignment.CenterVertically
+                    ) {
+                        TextButton(
+                            onClick = {
+                                onConfirmedYes()
+                                isDismissed = true
+                            },
+                            modifier = Modifier
+                                .padding(horizontal = 4.dp),
+
+                            ) {
+                            Text(
+                                style = typography.button,
+                                color = MaterialTheme.colors.primary,
+                                text = "Yes"
+                            )
+                        }
+                        TextButton(
+                            onClick = {
+                                onConfirmedNo()
+                                isDismissed = true
+                            },
+                            modifier = Modifier
+                                .padding(horizontal = 4.dp),
+
+                            ) {
+                            Text(
+                                style = typography.button,
+                                color = MaterialTheme.colors.primary,
+                                text = "No"
+                            )
+                        }
                     }
                 }
             }

--- a/noty-android/app/composeapp/src/main/java/dev/shreyaspatil/noty/composeapp/ui/screens/NoteDetailsScreen.kt
+++ b/noty-android/app/composeapp/src/main/java/dev/shreyaspatil/noty/composeapp/ui/screens/NoteDetailsScreen.kt
@@ -56,6 +56,7 @@ import dev.shreyaspatil.noty.composeapp.component.action.DeleteAction
 import dev.shreyaspatil.noty.composeapp.component.action.ShareAction
 import dev.shreyaspatil.noty.composeapp.component.action.ShareActionItem
 import dev.shreyaspatil.noty.composeapp.component.action.ShareDropdown
+import dev.shreyaspatil.noty.composeapp.component.dialog.ConfirmationDialog
 import dev.shreyaspatil.noty.composeapp.component.dialog.FailureDialog
 import dev.shreyaspatil.noty.composeapp.component.text.NoteField
 import dev.shreyaspatil.noty.composeapp.component.text.NoteTitleField
@@ -79,9 +80,7 @@ fun NoteDetailsScreen(
     viewModel: NoteDetailViewModel
 ) {
 
-    val focusRequester = remember {
-        FocusRequester()
-    }
+    val focusRequester = remember { FocusRequester() }
     val context = LocalContext.current
 
     val updateState = viewModel.updateNoteState.collectAsState(initial = null)
@@ -93,6 +92,17 @@ fun NoteDetailsScreen(
         var titleText by remember { mutableStateOf(note.title) }
         var noteText by remember { mutableStateOf(note.note) }
         var captureNoteImageRequestKey: Int? by remember { mutableStateOf(null) }
+        var showDeleteNoteConfirmation by remember { mutableStateOf(false) }
+
+        if (showDeleteNoteConfirmation) {
+            ConfirmationDialog(
+                title = "Delete?",
+                message = "Sure want to delete this note?",
+                onConfirmedYes = { viewModel.deleteNote() },
+                onConfirmedNo = { showDeleteNoteConfirmation = false },
+                onDismissed = { showDeleteNoteConfirmation = false }
+            )
+        }
 
         Scaffold(
             modifier = Modifier
@@ -125,15 +135,11 @@ fun NoteDetailsScreen(
                     elevation = 0.dp,
                     actions = {
                         var dropdownExpanded by remember { mutableStateOf(false) }
-                        DeleteAction(onClick = { viewModel.deleteNote() })
-                        ShareAction(onClick = {
-                            dropdownExpanded = true
-                        })
+                        DeleteAction(onClick = { showDeleteNoteConfirmation = true })
+                        ShareAction(onClick = { dropdownExpanded = true })
                         ShareDropdown(
                             expanded = dropdownExpanded,
-                            onDismissRequest = {
-                                dropdownExpanded = false
-                            },
+                            onDismissRequest = { dropdownExpanded = false },
                             shareActions = listOf(
                                 ShareActionItem(
                                     label = "Text",

--- a/noty-android/app/composeapp/src/main/java/dev/shreyaspatil/noty/composeapp/ui/screens/NotesScreen.kt
+++ b/noty-android/app/composeapp/src/main/java/dev/shreyaspatil/noty/composeapp/ui/screens/NotesScreen.kt
@@ -33,6 +33,7 @@ import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
@@ -48,6 +49,7 @@ import dev.shreyaspatil.noty.composeapp.component.NotesList
 import dev.shreyaspatil.noty.composeapp.component.action.AboutAction
 import dev.shreyaspatil.noty.composeapp.component.action.LogoutAction
 import dev.shreyaspatil.noty.composeapp.component.action.ThemeSwitchAction
+import dev.shreyaspatil.noty.composeapp.component.dialog.ConfirmationDialog
 import dev.shreyaspatil.noty.composeapp.component.dialog.FailureDialog
 import dev.shreyaspatil.noty.composeapp.navigation.NOTY_NAV_HOST_ROUTE
 import dev.shreyaspatil.noty.composeapp.ui.Screen
@@ -73,6 +75,20 @@ fun NotesScreen(navController: NavHostController, viewModel: NotesViewModel) {
 
     val isInDarkMode = isSystemInDarkTheme()
 
+    var showLogoutConfirmationDialog by remember { mutableStateOf(false) }
+
+    if (showLogoutConfirmationDialog) {
+        ConfirmationDialog(
+            title = "Logout?",
+            message = "Sure want to logout?",
+            onConfirmedYes = {
+                scope.launch { viewModel.clearUserSession() }
+            },
+            onConfirmedNo = { showLogoutConfirmationDialog = false },
+            onDismissed = { showLogoutConfirmationDialog = false }
+        )
+    }
+
     Scaffold(
         topBar = {
             TopAppBar(
@@ -94,11 +110,7 @@ fun NotesScreen(navController: NavHostController, viewModel: NotesViewModel) {
                             Screen.About.route
                         )
                     }
-                    LogoutAction(
-                        onLogout = {
-                            scope.launch { viewModel.clearUserSession() }
-                        }
-                    )
+                    LogoutAction(onLogout = { showLogoutConfirmationDialog = true })
                 }
             )
         },


### PR DESCRIPTION
## Summary

- Show confirmation dialogs on 
    - [#297] Before logging out on notes the main screen.
    - [#287] Before deleting a note on the note detail screen.

## Checklist

<!--
The current CI workflow will validate code level changes. 
Make sure that `./gradlew build` is passing before raising a PR. If build is failing at linting then just 
execute `./gradlew ktlintFormat` which will reformat code according to our code standards.
Other than this, it's encouraged if you pay attention to the below checklist.
-->

- [x] Build and linting is passing.
- [x] This change is not breaking existing flow of a system.
- [ ] I have written test case for this change.
- [x] This change is tested from all aspects.
- [ ] Implemented any new third-party library _(Which not existed before this change)_.
