### PR TITLE
[ComposeApp] Fix navigation issues

### DIFF
--- a/noty-android/app/composeapp/src/main/java/dev/shreyaspatil/noty/composeapp/ui/screens/LoginScreen.kt
+++ b/noty-android/app/composeapp/src/main/java/dev/shreyaspatil/noty/composeapp/ui/screens/LoginScreen.kt
@@ -29,6 +29,7 @@ import androidx.compose.material.Button
 import androidx.compose.material.MaterialTheme
 import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
@@ -49,6 +50,7 @@ import dev.shreyaspatil.noty.composeapp.component.dialog.LoaderDialog
 import dev.shreyaspatil.noty.composeapp.component.text.PasswordTextField
 import dev.shreyaspatil.noty.composeapp.component.text.TextFieldValue
 import dev.shreyaspatil.noty.composeapp.component.text.UsernameTextField
+import dev.shreyaspatil.noty.composeapp.navigation.NOTY_NAV_HOST_ROUTE
 import dev.shreyaspatil.noty.composeapp.ui.Screen
 import dev.shreyaspatil.noty.composeapp.ui.theme.typography
 import dev.shreyaspatil.noty.core.ui.UIDataState
@@ -64,12 +66,6 @@ fun LoginScreen(navController: NavHostController, loginViewModel: LoginViewModel
     when (viewState) {
         is UIDataState.Loading -> LoaderDialog()
         is UIDataState.Failed -> FailureDialog(viewState.message)
-        is UIDataState.Success -> {
-            navController.navigate(Screen.Notes.route) {
-                launchSingleTop = true
-                popUpTo(Screen.Login.route) { inclusive = true }
-            }
-        }
     }
 
     LazyColumn(
@@ -181,6 +177,15 @@ fun LoginScreen(navController: NavHostController, loginViewModel: LoginViewModel
                             }
                         )
                 )
+            }
+        }
+    }
+
+    LaunchedEffect(viewState?.isSuccess) {
+        if (viewState?.isSuccess == true) {
+            navController.navigate(Screen.Notes.route) {
+                launchSingleTop = true
+                popUpTo(NOTY_NAV_HOST_ROUTE)
             }
         }
     }

--- a/noty-android/app/composeapp/src/main/java/dev/shreyaspatil/noty/composeapp/ui/screens/NotesScreen.kt
+++ b/noty-android/app/composeapp/src/main/java/dev/shreyaspatil/noty/composeapp/ui/screens/NotesScreen.kt
@@ -66,11 +66,6 @@ import kotlinx.coroutines.launch
 fun NotesScreen(navController: NavHostController, viewModel: NotesViewModel) {
     val isUserLoggedIn by viewModel.userLoggedInState.collectAsState()
 
-    if (!isUserLoggedIn) {
-        navigateToLogin(navController)
-        return
-    }
-
     val scope = rememberCoroutineScope()
 
     val isInDarkMode = isSystemInDarkTheme()
@@ -163,6 +158,12 @@ fun NotesScreen(navController: NavHostController, viewModel: NotesViewModel) {
             }
         }
     )
+
+    LaunchedEffect(key1 = isUserLoggedIn) {
+        if (!isUserLoggedIn) {
+            navigateToLogin(navController)
+        }
+    }
 }
 
 private fun navigateToLogin(navController: NavHostController) {

--- a/noty-android/app/composeapp/src/main/java/dev/shreyaspatil/noty/composeapp/ui/screens/SignUpScreen.kt
+++ b/noty-android/app/composeapp/src/main/java/dev/shreyaspatil/noty/composeapp/ui/screens/SignUpScreen.kt
@@ -27,6 +27,7 @@ import androidx.compose.material.Button
 import androidx.compose.material.MaterialTheme
 import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
@@ -45,6 +46,7 @@ import dev.shreyaspatil.noty.composeapp.component.text.ConfirmPasswordTextField
 import dev.shreyaspatil.noty.composeapp.component.text.PasswordTextField
 import dev.shreyaspatil.noty.composeapp.component.text.TextFieldValue.Valid
 import dev.shreyaspatil.noty.composeapp.component.text.UsernameTextField
+import dev.shreyaspatil.noty.composeapp.navigation.NOTY_NAV_HOST_ROUTE
 import dev.shreyaspatil.noty.composeapp.ui.Screen
 import dev.shreyaspatil.noty.composeapp.ui.theme.typography
 import dev.shreyaspatil.noty.core.ui.UIDataState
@@ -62,12 +64,6 @@ fun SignUpScreen(
 
     when (viewState) {
         is UIDataState.Loading -> LoaderDialog()
-        is UIDataState.Success -> {
-            navController.navigate(Screen.Notes.route) {
-                launchSingleTop = true
-                popUpTo(Screen.SignUp.route) { inclusive = true }
-            }
-        }
         is UIDataState.Failed -> FailureDialog(viewState.message)
     }
 
@@ -186,6 +182,15 @@ fun SignUpScreen(
                             }
                         )
                 )
+            }
+        }
+    }
+
+    LaunchedEffect(viewState?.isSuccess) {
+        if (viewState?.isSuccess == true) {
+            navController.navigate(Screen.Notes.route) {
+                launchSingleTop = true
+                popUpTo(NOTY_NAV_HOST_ROUTE)
             }
         }
     }


### PR DESCRIPTION
## Summary

Fix internal app navigation issues in Jetpack Compose app module

## Description for the changelog

- #281 Fix: Earlier, After signup, navigating back takes to log in screen. Now it closes the app.
- #294 Fix: Earlier, recompositions were happening after performing navigation through screens.

## Checklist

<!--
The current CI workflow will validate code level changes. 
Make sure that `./gradlew build` is passing before raising a PR. If build is failing at linting then just 
execute `./gradlew ktlintFormat` which will reformat code according to our code standards.
Other than this, it's encouraged if you pay attention to the below checklist.
-->

- [x] Build and linting is passing.
- [x] This change is not breaking existing flow of a system.
- [ ] I have written test case for this change.
- [x] This change is tested from all aspects.
- [ ] Implemented any new third-party library _(Which not existed before this change)_.
