### PR TITLE
Update tooling and dependency versions

### DIFF
--- a/noty-android/app/build.gradle
+++ b/noty-android/app/build.gradle
@@ -21,7 +21,6 @@ apply plugin: 'dagger.hilt.android.plugin'
 
 android {
     compileSdkVersion ProjectConfig.compileSdkVersion
-    buildToolsVersion ProjectConfig.buildToolsVersion
 
     defaultConfig {
         minSdkVersion ProjectConfig.minSdkVersion

--- a/noty-android/app/composeapp/build.gradle
+++ b/noty-android/app/composeapp/build.gradle
@@ -109,6 +109,7 @@ dependencies {
     implementation "com.airbnb.android:lottie-compose:$lottieComposeVersion"
 
     // Compose
+    implementation "androidx.activity:activity-compose:$activityVersion"
     implementation "androidx.compose.runtime:runtime:$composeVersion"
     implementation "androidx.compose.ui:ui:$composeVersion"
     implementation "androidx.compose.foundation:foundation:$composeVersion"

--- a/noty-android/app/composeapp/build.gradle
+++ b/noty-android/app/composeapp/build.gradle
@@ -23,7 +23,6 @@ plugins {
 
 android {
     compileSdkVersion ProjectConfig.compileSdkVersion
-    buildToolsVersion ProjectConfig.buildToolsVersion
 
     defaultConfig {
         applicationId "dev.shreyaspatil.noty.composeapp"

--- a/noty-android/app/composeapp/build.gradle
+++ b/noty-android/app/composeapp/build.gradle
@@ -133,8 +133,9 @@ dependencies {
     implementation "androidx.work:work-runtime-ktx:$workmanagerVersion"
 
     // Lifecycle
-    implementation "androidx.lifecycle:lifecycle-viewmodel-compose:$lifecycleViewModelComposeVersion"
+    implementation "androidx.lifecycle:lifecycle-viewmodel-compose:$lifecycleVersion"
     implementation "androidx.lifecycle:lifecycle-runtime-ktx:$lifecycleVersion"
+    implementation "androidx.lifecycle:lifecycle-extensions:$lifecycleVersion"
 
     // Compose Lifecycle
     implementation "androidx.compose.runtime:runtime-livedata:$composeVersion"

--- a/noty-android/app/composeapp/build.gradle
+++ b/noty-android/app/composeapp/build.gradle
@@ -135,7 +135,6 @@ dependencies {
     // Lifecycle
     implementation "androidx.lifecycle:lifecycle-viewmodel-compose:$lifecycleVersion"
     implementation "androidx.lifecycle:lifecycle-runtime-ktx:$lifecycleVersion"
-    implementation "androidx.lifecycle:lifecycle-extensions:$lifecycleVersion"
 
     // Compose Lifecycle
     implementation "androidx.compose.runtime:runtime-livedata:$composeVersion"

--- a/noty-android/app/composeapp/build.gradle
+++ b/noty-android/app/composeapp/build.gradle
@@ -86,10 +86,6 @@ kapt {
     correctErrorTypes true
 }
 
-configurations {
-    devDebugImplementation {}
-}
-
 dependencies {
     // Kotlin Stdlib
     implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlinVersion"

--- a/noty-android/app/simpleapp/build.gradle
+++ b/noty-android/app/simpleapp/build.gradle
@@ -62,10 +62,6 @@ android {
     }
 }
 
-configurations {
-    devDebugImplementation {}
-}
-
 tasks.withType(org.jetbrains.kotlin.gradle.tasks.KotlinCompile).all {
     kotlinOptions {
         jvmTarget = "1.8"
@@ -130,5 +126,5 @@ dependencies {
 
     // Leak Canary
     // Uncomment this when have to check for leaks
-    // devDebugImplementation "com.squareup.leakcanary:leakcanary-android:$leakCanaryVersion"
+    // debugImplementation "com.squareup.leakcanary:leakcanary-android:$leakCanaryVersion"
 }

--- a/noty-android/app/simpleapp/build.gradle
+++ b/noty-android/app/simpleapp/build.gradle
@@ -102,7 +102,7 @@ dependencies {
     implementation "androidx.hilt:hilt-work:$jetpackHiltVersion"
 
     // Lifecycle
-    implementation "androidx.lifecycle:lifecycle-extensions:2.2.0"
+    implementation "androidx.lifecycle:lifecycle-extensions:$lifecycleVersion"
 
     // Material Design
     implementation "com.google.android.material:material:$materialDesignVersion"

--- a/noty-android/app/simpleapp/build.gradle
+++ b/noty-android/app/simpleapp/build.gradle
@@ -22,7 +22,6 @@ apply plugin: 'dagger.hilt.android.plugin'
 
 android {
     compileSdkVersion ProjectConfig.compileSdkVersion
-    buildToolsVersion ProjectConfig.buildToolsVersion
 
     defaultConfig {
         applicationId "dev.shreyaspatil.noty.simpleapp"

--- a/noty-android/app/simpleapp/build.gradle
+++ b/noty-android/app/simpleapp/build.gradle
@@ -93,6 +93,10 @@ dependencies {
     implementation "androidx.appcompat:appcompat:$appcompatVersion"
     implementation "androidx.constraintlayout:constraintlayout:$constraintlayoutVersion"
 
+    // Activity & Fragment
+    implementation "androidx.activity:activity-ktx:$activityVersion"
+    implementation "androidx.fragment:fragment-ktx:$fragmentVersion"
+
     // Dagger + Hilt
     implementation "com.google.dagger:hilt-android:$daggerHiltVersion"
     kapt "com.google.dagger:hilt-android-compiler:$daggerHiltVersion"
@@ -102,7 +106,7 @@ dependencies {
     implementation "androidx.hilt:hilt-work:$jetpackHiltVersion"
 
     // Lifecycle
-    implementation "androidx.lifecycle:lifecycle-extensions:$lifecycleVersion"
+    implementation "androidx.lifecycle:lifecycle-runtime-ktx:$lifecycleVersion"
 
     // Material Design
     implementation "com.google.android.material:material:$materialDesignVersion"

--- a/noty-android/app/src/test/java/dev/shreyaspatil/noty/task/NotyTaskManagerImplTest.kt
+++ b/noty-android/app/src/test/java/dev/shreyaspatil/noty/task/NotyTaskManagerImplTest.kt
@@ -44,7 +44,7 @@ import java.util.*
 
 class NotyTaskManagerImplTest : BehaviorSpec() {
 
-    override fun beforeSpec(spec: Spec) {
+    override suspend fun beforeSpec(spec: Spec) {
         super.beforeSpec(spec)
         setupAsyncTaskExecutor()
     }
@@ -167,7 +167,7 @@ class NotyTaskManagerImplTest : BehaviorSpec() {
         }
     }
 
-    override fun afterSpec(spec: Spec) {
+    override suspend fun afterSpec(spec: Spec) {
         super.afterSpec(spec)
         cleanupAsyncTaskExecutor()
     }

--- a/noty-android/data/local/build.gradle
+++ b/noty-android/data/local/build.gradle
@@ -20,7 +20,6 @@ apply plugin: 'kotlin-kapt'
 
 android {
     compileSdkVersion ProjectConfig.compileSdkVersion
-    buildToolsVersion ProjectConfig.buildToolsVersion
 
     defaultConfig {
         minSdkVersion ProjectConfig.minSdkVersion

--- a/noty-android/data/remote/build.gradle
+++ b/noty-android/data/remote/build.gradle
@@ -21,7 +21,6 @@ apply plugin: 'kotlin-kapt'
 
 android {
     compileSdkVersion ProjectConfig.compileSdkVersion
-    buildToolsVersion ProjectConfig.buildToolsVersion
 
     defaultConfig {
         minSdkVersion ProjectConfig.minSdkVersion

--- a/noty-android/dependencies.gradle
+++ b/noty-android/dependencies.gradle
@@ -19,10 +19,10 @@ ext {
     androidGradlePluginVersion = '7.2.0'
 
     // Kotlin
-    kotlinVersion = "1.6.10"
+    kotlinVersion = "1.6.21"
     ktlintVersion = "10.3.0"
     coroutinesVersion = "1.6.1"
-    koverVersion = "0.5.0"
+    koverVersion = "0.5.1"
 
     jacocoVersion = "0.8.8"
 
@@ -66,7 +66,7 @@ ext {
     javaxInjectVersion = "1"
 
     // Jetpack Compose
-    composeVersion = "1.1.1"
+    composeVersion = "1.2.0-beta01"
 
     // Constrain Layout (Compose)
     composeConstraintLayoutVersion = "1.0.0"

--- a/noty-android/dependencies.gradle
+++ b/noty-android/dependencies.gradle
@@ -33,13 +33,17 @@ ext {
     swipeRefreshLayoutVersion = "1.1.0"
     recyclerViewVersion = "1.2.1"
     workmanagerVersion = '2.7.1'
-    lifecycleVersion = "2.4.1"
+    lifecycleVersion = "2.5.0-rc01"
     navigationVersion = "2.5.0-rc01"
     securityCryptoVersion = '1.1.0-alpha03'
     roomVersion = "2.4.2"
     dataStoreVersion = '1.0.0'
     legacySupportVersion = "1.0.0"
     capturableVersion = "1.0.3"
+
+    // Activity & Fragment
+    activityVersion = "1.4.0"
+    fragmentVersion = "1.4.0"
 
     // Design
     materialDesignVersion = "1.6.0"
@@ -72,7 +76,7 @@ ext {
     composeConstraintLayoutVersion = "1.0.0"
 
     // Jetpack Compose Navigation
-    composeNavVersion = "2.5.0-beta01"
+    composeNavVersion = "2.5.0-rc01"
 
     // Hilt Compose Navigation
     hiltComposeNavVersion = "1.0.0"

--- a/noty-android/dependencies.gradle
+++ b/noty-android/dependencies.gradle
@@ -77,8 +77,6 @@ ext {
     // Hilt Compose Navigation
     hiltComposeNavVersion = "1.0.0"
 
-    lifecycleViewModelComposeVersion = "2.4.1"
-
     // Accompanist
     accompanistVersion = "0.23.1"
 

--- a/noty-android/gradle.properties
+++ b/noty-android/gradle.properties
@@ -20,7 +20,6 @@ org.gradle.daemon=true
 
 kotlin.code.style=official
 kapt.incremental.apt=true
-kapt.use.worker.api=false
 
 android.useAndroidX=true
 android.enableJetifier=true

--- a/noty-android/gradle/wrapper/gradle-wrapper.properties
+++ b/noty-android/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Sat Jan 29 14:16:49 IST 2022
+#Sat May 14 13:27:27 IST 2022
 distributionBase=GRADLE_USER_HOME
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.2-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.3.3-bin.zip
 distributionPath=wrapper/dists
 zipStorePath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME

--- a/noty-android/projectConfig.gradle
+++ b/noty-android/projectConfig.gradle
@@ -17,7 +17,6 @@
 ext {
     ProjectConfig = [
             compileSdkVersion: 31,
-            buildToolsVersion: "30.0.2",
             minSdkVersion    : 21,
             targetSdkVersion : 31,
             versionCode      : 20211130,

--- a/noty-android/repository/build.gradle
+++ b/noty-android/repository/build.gradle
@@ -19,7 +19,6 @@ apply plugin: 'kotlin-kapt'
 
 android {
     compileSdkVersion ProjectConfig.compileSdkVersion
-    buildToolsVersion ProjectConfig.buildToolsVersion
 
     defaultConfig {
         minSdkVersion ProjectConfig.minSdkVersion


### PR DESCRIPTION
# Summary

- Updated Android Gradle plugin, Gradle wrapper, Kotlin, Kover and Jetpack Compose versions
- Removed unused or unnecessary properties from Gradle config.
- Migrate usage of `beforeSpec()` and `afterSpec()` of Kotest.
- Removed ambiguity of versions across navigation and lifecycle libraries.