### PR TITLE
Fix issue #535 for hiding the keyboard

### DIFF
--- a/noty-android/app/simpleapp/src/main/java/dev/shreyaspatil/noty/simpleapp/view/add/AddNoteFragment.kt
+++ b/noty-android/app/simpleapp/src/main/java/dev/shreyaspatil/noty/simpleapp/view/add/AddNoteFragment.kt
@@ -25,6 +25,7 @@ import dagger.hilt.android.AndroidEntryPoint
 import dev.shreyaspatil.noty.simpleapp.databinding.AddNoteFragmentBinding
 import dev.shreyaspatil.noty.simpleapp.view.base.BaseFragment
 import dev.shreyaspatil.noty.simpleapp.view.hiltNotyMainNavGraphViewModels
+import dev.shreyaspatil.noty.utils.ext.hideKeyboard
 import dev.shreyaspatil.noty.utils.ext.toStringOrEmpty
 import dev.shreyaspatil.noty.view.state.AddNoteState
 import dev.shreyaspatil.noty.view.viewmodel.AddNoteViewModel
@@ -50,6 +51,7 @@ class AddNoteFragment : BaseFragment<AddNoteFragmentBinding, AddNoteState, AddNo
         showProgressDialog(state.isAdding)
 
         if (state.added) {
+            hideKeyboard()
             findNavController().navigateUp()
         }
 

--- a/noty-android/app/simpleapp/src/main/java/dev/shreyaspatil/noty/simpleapp/view/detail/NoteDetailFragment.kt
+++ b/noty-android/app/simpleapp/src/main/java/dev/shreyaspatil/noty/simpleapp/view/detail/NoteDetailFragment.kt
@@ -36,6 +36,7 @@ import dagger.hilt.android.AndroidEntryPoint
 import dev.shreyaspatil.noty.simpleapp.R
 import dev.shreyaspatil.noty.simpleapp.databinding.NoteDetailFragmentBinding
 import dev.shreyaspatil.noty.simpleapp.view.base.BaseFragment
+import dev.shreyaspatil.noty.utils.ext.hideKeyboard
 import dev.shreyaspatil.noty.utils.ext.showDialog
 import dev.shreyaspatil.noty.utils.ext.toStringOrEmpty
 import dev.shreyaspatil.noty.utils.saveBitmap
@@ -109,6 +110,7 @@ class NoteDetailFragment :
         }
 
         if (state.finished) {
+            hideKeyboard()
             findNavController().navigateUp()
         }
 

--- a/noty-android/app/src/main/java/dev/shreyaspatil/noty/utils/ext/KeyboardExt.kt
+++ b/noty-android/app/src/main/java/dev/shreyaspatil/noty/utils/ext/KeyboardExt.kt
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2020 Shreyas Patil
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package dev.shreyaspatil.noty.utils.ext
+
+import android.app.Activity
+import android.content.Context
+import android.view.View
+import android.view.inputmethod.InputMethodManager
+import androidx.fragment.app.Fragment
+
+fun Fragment.hideKeyboard() {
+    view?.let { activity?.hideKeyboard(it) }
+}
+
+fun Context.hideKeyboard(view: View) {
+    val inputMethodManager = getSystemService(Activity.INPUT_METHOD_SERVICE) as InputMethodManager
+    inputMethodManager.hideSoftInputFromWindow(view.windowToken, 0)
+}


### PR DESCRIPTION

I've read and understood our contributing guidelines;
https://github.com/patilshreyas/NotyKT/blob/master/CONTRIBUTING.md


## Summary

When a new note is saved or an existing note is edited successfully, the keyboard was not being dismissed. 
This fixes the issue #535 

## Description for the changelog

- After successful login, when navigated to AddNewNoteFragment/NoteDetailFragment to add or edit a note, once successfully saving the note when navigated back to NotesListFragment, the soft keyboard is retained. The issue is fixed in this PR.


## Checklist

- [x] Build and linting is passing.
- [x] This change is not breaking existing flow of a system.
- [ ] I have written test case for this change.
- [ ] This change is tested from all aspects.
- [ ] Implemented any new third-party library _(Which not existed before this change)_.
