### PR TITLE
Fix issue 536 loading of progress indefinitely when no notes available

### DIFF
--- a/noty-android/app/simpleapp/src/main/java/dev/shreyaspatil/noty/simpleapp/view/notes/NotesFragment.kt
+++ b/noty-android/app/simpleapp/src/main/java/dev/shreyaspatil/noty/simpleapp/view/notes/NotesFragment.kt
@@ -172,8 +172,7 @@ class NotesFragment : BaseFragment<NotesFragmentBinding, NotesState, NotesViewMo
 
     private fun isConnected(): Boolean? = viewModel.currentState.isConnectivityAvailable
 
-    private fun shouldSyncNotes() = viewModel.currentState
-        .let { state -> state.error != null || state.notes.isEmpty() }
+    private fun shouldSyncNotes() = viewModel.currentState.error != null
 
     override fun getViewBinding(
         inflater: LayoutInflater,

--- a/noty-api/build.gradle
+++ b/noty-api/build.gradle
@@ -25,7 +25,7 @@ buildscript {
         postgresVersion = "42.3.1"
         logbackVersion = "1.4.1"
         daggerVersion = "2.44"
-        testContainerVersion = "1.17.3"
+        testContainerVersion = "1.17.4"
         kotestVersion = "5.4.2"
     }
 

--- a/noty-api/build.gradle
+++ b/noty-api/build.gradle
@@ -25,7 +25,7 @@ buildscript {
         postgresVersion = "42.3.1"
         logbackVersion = "1.4.1"
         daggerVersion = "2.44"
-        testContainerVersion = "1.17.4"
+        testContainerVersion = "1.17.5"
         kotestVersion = "5.5.0"
     }
 

--- a/noty-api/build.gradle
+++ b/noty-api/build.gradle
@@ -26,7 +26,7 @@ buildscript {
         logbackVersion = "1.4.1"
         daggerVersion = "2.44"
         testContainerVersion = "1.17.4"
-        kotestVersion = "5.4.2"
+        kotestVersion = "5.5.0"
     }
 
     repositories {

--- a/noty-api/build.gradle
+++ b/noty-api/build.gradle
@@ -23,7 +23,7 @@ buildscript {
         ktorVersion = "1.6.8"
         exposedVersion = "0.39.2"
         postgresVersion = "42.3.1"
-        logbackVersion = "1.4.1"
+        logbackVersion = "1.4.3"
         daggerVersion = "2.44"
         testContainerVersion = "1.17.5"
         kotestVersion = "5.5.0"


### PR DESCRIPTION
## Summary
When there are no notes available, progress dialog keeps loading indefinitely trying to sync the data. The PR fixes issue #536 

## Description for the changelog

When the user logs into the app for the first time, app tries to sync with backend indefinitely since notes list is empty. The same is observed when all the existing notes are deleted. Notes can be synced during the first load after logging in or any error occurs while syncing. The condition which would sync notes when list is empty is removed which fixes the above issue.



## Checklist

- [x] Build and linting is passing.
- [x] This change is not breaking existing flow of a system.
- [ ] I have written test case for this change.
- [ ] This change is tested from all aspects.
- [ ] Implemented any new third-party library _(Which not existed before this change)_.
