### PR TITLE
[Android] FEAT ~ added password visibility toggle

### DIFF
--- a/noty-android/app/composeapp/src/androidTest/java/dev/shreyaspatil/noty/composeapp/ui/screens/LoginScreenTest.kt
+++ b/noty-android/app/composeapp/src/androidTest/java/dev/shreyaspatil/noty/composeapp/ui/screens/LoginScreenTest.kt
@@ -20,6 +20,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.ui.ExperimentalComposeUiApi
 import androidx.compose.ui.platform.LocalSoftwareKeyboardController
+import androidx.compose.ui.test.assertContentDescriptionEquals
 import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
@@ -137,6 +138,19 @@ class LoginScreenTest : NotyScreenTest() {
         waitForIdle()
 
         assertTrue(navigatedToNotes)
+    }
+
+    @Test
+    fun testIfPasswordIsVisible_onEyeButtonClicked() = runTest {
+        onNodeWithTag(
+            testTag = "TogglePasswordVisibility",
+            useUnmergedTree = true
+        ).performClick()
+
+        onNodeWithTag(
+            testTag = "TogglePasswordVisibility",
+            useUnmergedTree = true
+        ).assertContentDescriptionEquals("Hide password")
     }
 
     @Composable

--- a/noty-android/app/composeapp/src/androidTest/java/dev/shreyaspatil/noty/composeapp/ui/screens/LoginScreenTest.kt
+++ b/noty-android/app/composeapp/src/androidTest/java/dev/shreyaspatil/noty/composeapp/ui/screens/LoginScreenTest.kt
@@ -142,6 +142,9 @@ class LoginScreenTest : NotyScreenTest() {
 
     @Test
     fun testIfPasswordIsVisible_onEyeButtonClicked() = runTest {
+        setNotyContent {
+            LoginScreen()
+        }
         onNodeWithTag(
             testTag = "TogglePasswordVisibility",
             useUnmergedTree = true

--- a/noty-android/app/composeapp/src/main/java/dev/shreyaspatil/noty/composeapp/component/text/CommonTextField.kt
+++ b/noty-android/app/composeapp/src/main/java/dev/shreyaspatil/noty/composeapp/component/text/CommonTextField.kt
@@ -48,10 +48,11 @@ fun NotyTextField(
     modifier: Modifier = Modifier,
     fontSize: TextUnit = 16.sp,
     color: Color = MaterialTheme.colors.onPrimary,
-    leadingIcon: @Composable() (() -> Unit)? = null,
+    leadingIcon: @Composable (() -> Unit)? = null,
     isError: Boolean = false,
     helperText: String = "",
-    visualTransformation: VisualTransformation = VisualTransformation.None
+    visualTransformation: VisualTransformation = VisualTransformation.None,
+    trailingIcon: @Composable (() -> Unit)? = null
 ) {
     Surface(modifier) {
         Column {
@@ -64,7 +65,8 @@ fun NotyTextField(
                 textStyle = TextStyle(color, fontSize = fontSize),
                 isError = isError,
                 visualTransformation = visualTransformation,
-                shape = RoundedCornerShape(8.dp)
+                shape = RoundedCornerShape(8.dp),
+                trailingIcon = trailingIcon
             )
             if (helperText.isNotEmpty()) {
                 Spacer(modifier = Modifier.padding(2.dp))

--- a/noty-android/app/composeapp/src/main/java/dev/shreyaspatil/noty/composeapp/component/text/PasswordTextField.kt
+++ b/noty-android/app/composeapp/src/main/java/dev/shreyaspatil/noty/composeapp/component/text/PasswordTextField.kt
@@ -17,12 +17,21 @@
 package dev.shreyaspatil.noty.composeapp.component.text
 
 import androidx.compose.material.Icon
+import androidx.compose.material.IconButton
 import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Visibility
+import androidx.compose.material.icons.filled.VisibilityOff
 import androidx.compose.material.icons.outlined.Password
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.input.PasswordVisualTransformation
+import androidx.compose.ui.text.input.VisualTransformation
 import dev.shreyaspatil.noty.composeapp.R
 
 @Composable
@@ -34,14 +43,30 @@ fun PasswordTextField(
     onValueChange: (String) -> Unit,
 ) {
 
+    var isPasswordVisible by remember { mutableStateOf(false) }
+
     NotyTextField(
         value = value,
         label = label,
         onValueChange = onValueChange,
         modifier = modifier,
         leadingIcon = { Icon(Icons.Outlined.Password, label) },
-        visualTransformation = PasswordVisualTransformation(),
+        visualTransformation = if (isPasswordVisible) VisualTransformation.None
+        else PasswordVisualTransformation(),
         isError = isError,
-        helperText = stringResource(R.string.message_field_password_invalid)
+        helperText = stringResource(R.string.message_field_password_invalid),
+        trailingIcon = {
+            val image = if (isPasswordVisible) Icons.Filled.Visibility
+            else Icons.Filled.VisibilityOff
+            val description = if (isPasswordVisible) "Hide password" else "Show password"
+
+            IconButton(onClick = { isPasswordVisible = !isPasswordVisible }) {
+                Icon(
+                    imageVector = image,
+                    contentDescription = description,
+                    modifier = Modifier.testTag("TogglePasswordVisibility")
+                )
+            }
+        }
     )
 }

--- a/noty-api/build.gradle
+++ b/noty-api/build.gradle
@@ -21,7 +21,7 @@ buildscript {
         ktlintVersion = "10.3.0"
         coroutinesVersion = "1.6.4"
         ktorVersion = "1.6.8"
-        exposedVersion = "0.39.2"
+        exposedVersion = "0.40.1"
         postgresVersion = "42.3.1"
         logbackVersion = "1.4.3"
         daggerVersion = "2.44"

--- a/noty-api/build.gradle
+++ b/noty-api/build.gradle
@@ -23,7 +23,7 @@ buildscript {
         ktorVersion = "1.6.8"
         exposedVersion = "0.39.2"
         postgresVersion = "42.3.1"
-        logbackVersion = "1.4.1"
+        logbackVersion = "1.4.3"
         daggerVersion = "2.44"
         testContainerVersion = "1.17.5"
         kotestVersion = "5.5.0"


### PR DESCRIPTION
## Summary

Password Visibility on Login Screen

## Description for the changelog

This adds a password visibility toggle icon to hide and show password on the login page.

## A picture or screenshot regarding change

![f2cec8c4-d718-49cc-b233-018904934560](https://user-images.githubusercontent.com/42339771/194354897-dc6848e6-defa-4c6d-87c8-d05d0a920190.png)


## Checklist

- [x] Build and linting is passing.
- [x] This change is not breaking existing flow of a system.
- [x] I have written test case for this change.
- [x] This change is tested from all aspects.
- [ ] Implemented any new third-party library _(Which not existed before this change)_.
