### PR TITLE
Replace deprecated OptionMenu APIs with MenuProvider

### DIFF
--- a/noty-android/app/simpleapp/src/main/java/dev/shreyaspatil/noty/simpleapp/view/detail/NoteDetailFragment.kt
+++ b/noty-android/app/simpleapp/src/main/java/dev/shreyaspatil/noty/simpleapp/view/detail/NoteDetailFragment.kt
@@ -23,13 +23,17 @@ import android.view.LayoutInflater
 import android.view.Menu
 import android.view.MenuInflater
 import android.view.MenuItem
+import android.view.View
 import android.view.ViewGroup
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.core.content.ContextCompat
+import androidx.core.view.MenuHost
+import androidx.core.view.MenuProvider
 import androidx.core.view.drawToBitmap
 import androidx.core.view.isVisible
 import androidx.core.widget.addTextChangedListener
 import androidx.fragment.app.viewModels
+import androidx.lifecycle.Lifecycle
 import androidx.navigation.fragment.findNavController
 import androidx.navigation.fragment.navArgs
 import dagger.hilt.android.AndroidEntryPoint
@@ -81,9 +85,35 @@ class NoteDetailFragment :
         )
     }
 
-    override fun onCreate(savedInstanceState: Bundle?) {
-        super.onCreate(savedInstanceState)
-        setHasOptionsMenu(true)
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+
+        val menuHost: MenuHost = requireActivity()
+
+        menuHost.addMenuProvider(
+            object : MenuProvider {
+                override fun onPrepareMenu(menu: Menu) {
+                    pinMenuItem = menu.findItem(R.id.action_pin)
+
+                    super.onPrepareMenu(menu)
+                }
+
+                override fun onCreateMenu(menu: Menu, menuInflater: MenuInflater) {
+                    menuInflater.inflate(R.menu.note_menu, menu)
+                }
+
+                override fun onMenuItemSelected(menuItem: MenuItem): Boolean {
+                    when (menuItem.itemId) {
+                        R.id.action_delete -> confirmNoteDeletion()
+                        R.id.action_pin -> viewModel.togglePin()
+                        R.id.action_share_text -> shareText()
+                        R.id.action_share_image -> shareImage()
+                    }
+                    return false
+                }
+            },
+            viewLifecycleOwner, Lifecycle.State.RESUMED
+        )
     }
 
     override fun initView() {
@@ -154,26 +184,6 @@ class NoteDetailFragment :
         requireContext(),
         Manifest.permission.WRITE_EXTERNAL_STORAGE
     ) == PackageManager.PERMISSION_GRANTED
-
-    override fun onCreateOptionsMenu(menu: Menu, inflater: MenuInflater) {
-        inflater.inflate(R.menu.note_menu, menu)
-        super.onCreateOptionsMenu(menu, inflater)
-    }
-
-    override fun onPrepareOptionsMenu(menu: Menu) {
-        pinMenuItem = menu.findItem(R.id.action_pin)
-        super.onPrepareOptionsMenu(menu)
-    }
-
-    override fun onOptionsItemSelected(item: MenuItem): Boolean {
-        when (item.itemId) {
-            R.id.action_delete -> confirmNoteDeletion()
-            R.id.action_pin -> viewModel.togglePin()
-            R.id.action_share_text -> shareText()
-            R.id.action_share_image -> shareImage()
-        }
-        return super.onOptionsItemSelected(item)
-    }
 
     override fun getViewBinding(
         inflater: LayoutInflater,

--- a/noty-android/app/simpleapp/src/main/java/dev/shreyaspatil/noty/simpleapp/view/detail/NoteDetailFragment.kt
+++ b/noty-android/app/simpleapp/src/main/java/dev/shreyaspatil/noty/simpleapp/view/detail/NoteDetailFragment.kt
@@ -88,32 +88,7 @@ class NoteDetailFragment :
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
 
-        val menuHost: MenuHost = requireActivity()
-
-        menuHost.addMenuProvider(
-            object : MenuProvider {
-                override fun onPrepareMenu(menu: Menu) {
-                    pinMenuItem = menu.findItem(R.id.action_pin)
-
-                    super.onPrepareMenu(menu)
-                }
-
-                override fun onCreateMenu(menu: Menu, menuInflater: MenuInflater) {
-                    menuInflater.inflate(R.menu.note_menu, menu)
-                }
-
-                override fun onMenuItemSelected(menuItem: MenuItem): Boolean {
-                    when (menuItem.itemId) {
-                        R.id.action_delete -> confirmNoteDeletion()
-                        R.id.action_pin -> viewModel.togglePin()
-                        R.id.action_share_text -> shareText()
-                        R.id.action_share_image -> shareImage()
-                    }
-                    return false
-                }
-            },
-            viewLifecycleOwner, Lifecycle.State.RESUMED
-        )
+        setupMenu()
     }
 
     override fun initView() {
@@ -148,6 +123,35 @@ class NoteDetailFragment :
         }
 
         updatePinnedIcon(state.isPinned)
+    }
+
+    private fun setupMenu() {
+        val menuHost: MenuHost = requireActivity()
+
+        menuHost.addMenuProvider(
+            object : MenuProvider {
+                override fun onPrepareMenu(menu: Menu) {
+                    pinMenuItem = menu.findItem(R.id.action_pin)
+
+                    super.onPrepareMenu(menu)
+                }
+
+                override fun onCreateMenu(menu: Menu, menuInflater: MenuInflater) {
+                    menuInflater.inflate(R.menu.note_menu, menu)
+                }
+
+                override fun onMenuItemSelected(menuItem: MenuItem): Boolean {
+                    when (menuItem.itemId) {
+                        R.id.action_delete -> confirmNoteDeletion()
+                        R.id.action_pin -> viewModel.togglePin()
+                        R.id.action_share_text -> shareText()
+                        R.id.action_share_image -> shareImage()
+                    }
+                    return false
+                }
+            },
+            viewLifecycleOwner, Lifecycle.State.RESUMED
+        )
     }
 
     private fun updatePinnedIcon(isPinned: Boolean) {

--- a/noty-android/app/simpleapp/src/main/java/dev/shreyaspatil/noty/simpleapp/view/notes/NotesFragment.kt
+++ b/noty-android/app/simpleapp/src/main/java/dev/shreyaspatil/noty/simpleapp/view/notes/NotesFragment.kt
@@ -58,42 +58,7 @@ class NotesFragment : BaseFragment<NotesFragmentBinding, NotesState, NotesViewMo
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
 
-        val menuHost: MenuHost = requireActivity()
-
-        menuHost.addMenuProvider(
-            object : MenuProvider {
-
-                override fun onPrepareMenu(menu: Menu) {
-                    viewLifecycleOwner.lifecycleScope.launch {
-                        when (viewModel.isDarkModeEnabled()) {
-                            true -> {
-                                menu.findItem(R.id.action_dark_mode).isVisible = false
-                            }
-                            false -> {
-                                menu.findItem(R.id.action_light_mode).isVisible = false
-                            }
-                        }
-                        super.onPrepareMenu(menu)
-                    }
-                }
-
-                override fun onCreateMenu(menu: Menu, menuInflater: MenuInflater) {
-                    menuInflater.inflate(R.menu.main_menu, menu)
-                }
-
-                override fun onMenuItemSelected(menuItem: MenuItem): Boolean {
-                    when (menuItem.itemId) {
-                        R.id.action_light_mode -> viewModel.setDarkMode(false)
-                        R.id.action_dark_mode -> viewModel.setDarkMode(true)
-                        R.id.action_about ->
-                            findNavController().navigate(R.id.action_notesFragment_to_aboutFragment)
-                        R.id.action_logout -> confirmLogout()
-                    }
-                    return false
-                }
-            },
-            viewLifecycleOwner, Lifecycle.State.RESUMED
-        )
+        setupMenu()
     }
 
     override fun initView() {
@@ -242,6 +207,45 @@ class NotesFragment : BaseFragment<NotesFragmentBinding, NotesState, NotesViewMo
                 }
             }
         } else return
+    }
+
+    private fun setupMenu() {
+        val menuHost: MenuHost = requireActivity()
+
+        menuHost.addMenuProvider(
+            object : MenuProvider {
+
+                override fun onPrepareMenu(menu: Menu) {
+                    viewLifecycleOwner.lifecycleScope.launch {
+                        when (viewModel.isDarkModeEnabled()) {
+                            true -> {
+                                menu.findItem(R.id.action_dark_mode).isVisible = false
+                            }
+                            false -> {
+                                menu.findItem(R.id.action_light_mode).isVisible = false
+                            }
+                        }
+                        super.onPrepareMenu(menu)
+                    }
+                }
+
+                override fun onCreateMenu(menu: Menu, menuInflater: MenuInflater) {
+                    menuInflater.inflate(R.menu.main_menu, menu)
+                }
+
+                override fun onMenuItemSelected(menuItem: MenuItem): Boolean {
+                    when (menuItem.itemId) {
+                        R.id.action_light_mode -> viewModel.setDarkMode(false)
+                        R.id.action_dark_mode -> viewModel.setDarkMode(true)
+                        R.id.action_about ->
+                            findNavController().navigate(R.id.action_notesFragment_to_aboutFragment)
+                        R.id.action_logout -> confirmLogout()
+                    }
+                    return false
+                }
+            },
+            viewLifecycleOwner, Lifecycle.State.RESUMED
+        )
     }
 
     companion object {

--- a/noty-android/app/simpleapp/src/main/java/dev/shreyaspatil/noty/simpleapp/view/notes/NotesFragment.kt
+++ b/noty-android/app/simpleapp/src/main/java/dev/shreyaspatil/noty/simpleapp/view/notes/NotesFragment.kt
@@ -23,9 +23,13 @@ import android.view.LayoutInflater
 import android.view.Menu
 import android.view.MenuInflater
 import android.view.MenuItem
+import android.view.View
 import android.view.ViewGroup
 import androidx.core.content.ContextCompat
 import androidx.core.content.res.ResourcesCompat
+import androidx.core.view.MenuHost
+import androidx.core.view.MenuProvider
+import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.lifecycleScope
 import androidx.navigation.fragment.findNavController
 import dagger.hilt.android.AndroidEntryPoint
@@ -51,9 +55,45 @@ class NotesFragment : BaseFragment<NotesFragmentBinding, NotesState, NotesViewMo
 
     private val notesListAdapter by autoCleaned(initializer = { NotesListAdapter(::onNoteClicked) })
 
-    override fun onCreate(savedInstanceState: Bundle?) {
-        super.onCreate(savedInstanceState)
-        setHasOptionsMenu(true)
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+
+        val menuHost: MenuHost = requireActivity()
+
+        menuHost.addMenuProvider(
+            object : MenuProvider {
+
+                override fun onPrepareMenu(menu: Menu) {
+                    viewLifecycleOwner.lifecycleScope.launch {
+                        when (viewModel.isDarkModeEnabled()) {
+                            true -> {
+                                menu.findItem(R.id.action_dark_mode).isVisible = false
+                            }
+                            false -> {
+                                menu.findItem(R.id.action_light_mode).isVisible = false
+                            }
+                        }
+                        super.onPrepareMenu(menu)
+                    }
+                }
+
+                override fun onCreateMenu(menu: Menu, menuInflater: MenuInflater) {
+                    menuInflater.inflate(R.menu.main_menu, menu)
+                }
+
+                override fun onMenuItemSelected(menuItem: MenuItem): Boolean {
+                    when (menuItem.itemId) {
+                        R.id.action_light_mode -> viewModel.setDarkMode(false)
+                        R.id.action_dark_mode -> viewModel.setDarkMode(true)
+                        R.id.action_about ->
+                            findNavController().navigate(R.id.action_notesFragment_to_aboutFragment)
+                        R.id.action_logout -> confirmLogout()
+                    }
+                    return false
+                }
+            },
+            viewLifecycleOwner, Lifecycle.State.RESUMED
+        )
     }
 
     override fun initView() {
@@ -179,36 +219,6 @@ class NotesFragment : BaseFragment<NotesFragmentBinding, NotesState, NotesViewMo
         inflater: LayoutInflater,
         container: ViewGroup?
     ) = NotesFragmentBinding.inflate(inflater, container, false)
-
-    override fun onPrepareOptionsMenu(menu: Menu) {
-        viewLifecycleOwner.lifecycleScope.launch {
-            when (viewModel.isDarkModeEnabled()) {
-                true -> {
-                    menu.findItem(R.id.action_dark_mode).isVisible = false
-                }
-                false -> {
-                    menu.findItem(R.id.action_light_mode).isVisible = false
-                }
-            }
-            super.onPrepareOptionsMenu(menu)
-        }
-    }
-
-    override fun onCreateOptionsMenu(menu: Menu, inflater: MenuInflater) {
-        inflater.inflate(R.menu.main_menu, menu)
-        super.onCreateOptionsMenu(menu, inflater)
-    }
-
-    override fun onOptionsItemSelected(item: MenuItem): Boolean {
-        when (item.itemId) {
-            R.id.action_light_mode -> viewModel.setDarkMode(false)
-            R.id.action_dark_mode -> viewModel.setDarkMode(true)
-            R.id.action_about ->
-                findNavController().navigate(R.id.action_notesFragment_to_aboutFragment)
-            R.id.action_logout -> confirmLogout()
-        }
-        return super.onOptionsItemSelected(item)
-    }
 
     private fun confirmLogout() {
         showDialog(


### PR DESCRIPTION
## Summary

Replace deprecated OptionMenu APIs with MenuProvider
This closes issue #547 


## Checklist

- [x] Build and linting is passing.
- [x] This change is not breaking existing flow of a system.
- [ ] I have written test case for this change.
- [x] This change is tested from all aspects.
