### PR TITLE
Fix #619: Show recently added notes first

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -16,4 +16,5 @@ If you want to discuss on something then feel free to present your opinions, vie
 - New code addition/deletion should not break existing flow of a system.
 - All tests should be passed.
 - Verify `./gradlew build` is passing before raising a PR.
+- Run UI tests using `./gradlew connectedCheck` to make sure UI tests are passing.
 - Reformat code with KtLint `./gradlew ktlintFormat` before raising a PR.

--- a/docs/pages/noty-android/compose_report.html
+++ b/docs/pages/noty-android/compose_report.html
@@ -152,7 +152,7 @@ footer {
           </tr>
           <tr>
             <th>Static Arguments</th>
-            <td>218</td>
+            <td>217</td>
           </tr>
           <tr>
             <th>Certain Arguments</th>
@@ -279,7 +279,7 @@ footer {
             <td>0</td>
             <td>0</td>
             <td>1</td>
-            <td>2</td>
+            <td>1</td>
           </tr>
           <tr>
             <td>dev.shreyaspatil.noty.composeapp.component.action.DeleteAction</td>

--- a/noty-android/.editorconfig
+++ b/noty-android/.editorconfig
@@ -747,7 +747,7 @@ ij_xml_line_comment_at_first_column = true
 ij_xml_use_custom_settings = true
 
 [{*.kt, *.kts}]
-disabled_rules = no-wildcard-imports, import-ordering
+ktlint_disabled_rules = no-wildcard-imports, import-ordering
 ij_kotlin_align_in_columns_case_branch = false
 ij_kotlin_align_multiline_binary_operation = false
 ij_kotlin_align_multiline_extends_list = false

--- a/noty-android/app/composeapp/build.gradle
+++ b/noty-android/app/composeapp/build.gradle
@@ -73,6 +73,14 @@ android {
     lint {
         abortOnError false
     }
+    packagingOptions {
+        exclude 'META-INF/LICENSE.txt'
+        exclude 'META-INF/LICENSE.md'
+        exclude 'META-INF/NOTICE.txt'
+        exclude 'META-INF/NOTICE'
+        exclude 'META-INF/LICENSE'
+        exclude 'META-INF/DEPENDENCIES'
+    }
     namespace 'dev.shreyaspatil.noty.composeapp'
 
 }

--- a/noty-android/app/composeapp/src/androidTest/java/dev/shreyaspatil/noty/composeapp/fake/service/FakeNotyService.kt
+++ b/noty-android/app/composeapp/src/androidTest/java/dev/shreyaspatil/noty/composeapp/fake/service/FakeNotyService.kt
@@ -19,6 +19,7 @@ package dev.shreyaspatil.noty.composeapp.fake.service
 import dev.shreyaspatil.noty.composeapp.testUtil.successResponse
 import dev.shreyaspatil.noty.data.remote.api.NotyService
 import dev.shreyaspatil.noty.data.remote.model.request.NoteRequest
+import dev.shreyaspatil.noty.data.remote.model.request.NoteUpdatePinRequest
 import dev.shreyaspatil.noty.data.remote.model.response.NoteResponse
 import dev.shreyaspatil.noty.data.remote.model.response.NotesResponse
 import dev.shreyaspatil.noty.data.remote.model.response.State
@@ -51,6 +52,13 @@ class FakeNotyService @Inject constructor() : NotyService {
 
     override suspend fun deleteNote(noteId: String): Response<NoteResponse> {
         // Do nothing, just return success
+        return successResponse(NoteResponse(State.SUCCESS, "", ""))
+    }
+
+    override suspend fun updateNotePin(
+        noteId: String,
+        noteRequest: NoteUpdatePinRequest
+    ): Response<NoteResponse> {
         return successResponse(NoteResponse(State.SUCCESS, "", ""))
     }
 }

--- a/noty-android/app/composeapp/src/androidTest/java/dev/shreyaspatil/noty/composeapp/ui/screens/NoteDetailsScreenTest.kt
+++ b/noty-android/app/composeapp/src/androidTest/java/dev/shreyaspatil/noty/composeapp/ui/screens/NoteDetailsScreenTest.kt
@@ -18,8 +18,10 @@ package dev.shreyaspatil.noty.composeapp.ui.screens
 
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.test.IdlingResource
+import androidx.compose.ui.test.assertContentDescriptionEquals
 import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.onNodeWithContentDescription
+import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
 import androidx.compose.ui.test.performTextClearance
@@ -32,6 +34,7 @@ import dev.shreyaspatil.noty.core.repository.NotyNoteRepository
 import dev.shreyaspatil.noty.di.LocalRepository
 import dev.shreyaspatil.noty.view.viewmodel.NoteDetailViewModel
 import kotlinx.coroutines.GlobalScope
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 import org.junit.Assert.assertTrue
 import org.junit.Before
@@ -131,6 +134,26 @@ class NoteDetailsScreenTest : NotyScreenTest() {
         assertTrue(navigatingUp)
     }
 
+    @Test
+    fun showActionToUnpinNote_whenNoteIsAlreadyPinned() = runTest {
+        registerIdlingResource(setNoteIsPinned(true))
+        setNotyContent { NoteDetailScreen() }
+        waitForIdle()
+
+        onNodeWithTag("actionTogglePin", useUnmergedTree = true)
+            .assertContentDescriptionEquals("Pinned")
+    }
+
+    @Test
+    fun showActionToPinNote_whenNoteIsNotPinned() = runTest {
+        registerIdlingResource(setNoteIsPinned(false))
+        setNotyContent { NoteDetailScreen() }
+        waitForIdle()
+
+        onNodeWithTag("actionTogglePin", useUnmergedTree = true)
+            .assertContentDescriptionEquals("Not Pinned")
+    }
+
     @Composable
     private fun NoteDetailScreen(onNavigateUp: () -> Unit = {}) {
         NoteDetailsScreen(
@@ -153,6 +176,18 @@ class NoteDetailsScreenTest : NotyScreenTest() {
             )
             GlobalScope.launch {
                 noteRepository.addNotes(listOf(note))
+                isIdleNow = true
+            }
+        }
+    }
+
+    private fun setNoteIsPinned(isPinned: Boolean) = object : IdlingResource {
+        override var isIdleNow: Boolean = false
+
+        init {
+            GlobalScope.launch {
+                noteRepository.pinNote("1", isPinned)
+                delay(1000)
                 isIdleNow = true
             }
         }

--- a/noty-android/app/composeapp/src/androidTest/java/dev/shreyaspatil/noty/composeapp/ui/screens/NotesScreenTest.kt
+++ b/noty-android/app/composeapp/src/androidTest/java/dev/shreyaspatil/noty/composeapp/ui/screens/NotesScreenTest.kt
@@ -196,13 +196,13 @@ class NotesScreenTest : NotyScreenTest() {
         setNotyContent { NotesScreen(onNavigateToNoteDetail = { navigateToNoteId = it }) }
         registerIdlingResource(prefillNotes())
 
-        onNodeWithText("Lorem Ipsum 49", useUnmergedTree = true).performClick()
+        onNodeWithText("Lorem Ipsum 1", useUnmergedTree = true).performClick()
         waitForIdle()
-        assertEquals("49", navigateToNoteId)
+        assertEquals("1", navigateToNoteId)
 
-        onNodeWithText("Hello World 48", useUnmergedTree = true).performClick()
+        onNodeWithText("Hello World 2", useUnmergedTree = true).performClick()
         waitForIdle()
-        assertEquals("48", navigateToNoteId)
+        assertEquals("2", navigateToNoteId)
     }
 
     @Composable
@@ -231,8 +231,7 @@ class NotesScreenTest : NotyScreenTest() {
                 id = it.toString(),
                 title = "$title $it",
                 note = "$note $it",
-                created = currentTime - it.toLong(),
-                isPinned = false
+                created = currentTime - it.toLong()
             )
         }
     }

--- a/noty-android/app/composeapp/src/androidTest/java/dev/shreyaspatil/noty/composeapp/ui/screens/NotesScreenTest.kt
+++ b/noty-android/app/composeapp/src/androidTest/java/dev/shreyaspatil/noty/composeapp/ui/screens/NotesScreenTest.kt
@@ -196,13 +196,13 @@ class NotesScreenTest : NotyScreenTest() {
         setNotyContent { NotesScreen(onNavigateToNoteDetail = { navigateToNoteId = it }) }
         registerIdlingResource(prefillNotes())
 
-        onNodeWithText("Lorem Ipsum 1", useUnmergedTree = true).performClick()
-        waitForIdle()
-        assertEquals("1", navigateToNoteId)
-
-        onNodeWithText("Hello World 2", useUnmergedTree = true).performClick()
+        onNodeWithText("Lorem Ipsum 2", useUnmergedTree = true).performClick()
         waitForIdle()
         assertEquals("2", navigateToNoteId)
+
+        onNodeWithText("Hello World 3", useUnmergedTree = true).performClick()
+        waitForIdle()
+        assertEquals("3", navigateToNoteId)
     }
 
     @Composable

--- a/noty-android/app/composeapp/src/androidTest/java/dev/shreyaspatil/noty/composeapp/ui/screens/NotesScreenTest.kt
+++ b/noty-android/app/composeapp/src/androidTest/java/dev/shreyaspatil/noty/composeapp/ui/screens/NotesScreenTest.kt
@@ -196,13 +196,13 @@ class NotesScreenTest : NotyScreenTest() {
         setNotyContent { NotesScreen(onNavigateToNoteDetail = { navigateToNoteId = it }) }
         registerIdlingResource(prefillNotes())
 
-        onNodeWithText("Lorem Ipsum 1", useUnmergedTree = true).performClick()
+        onNodeWithText("Lorem Ipsum 49", useUnmergedTree = true).performClick()
         waitForIdle()
-        assertEquals("1", navigateToNoteId)
+        assertEquals("49", navigateToNoteId)
 
-        onNodeWithText("Hello World 2", useUnmergedTree = true).performClick()
+        onNodeWithText("Hello World 48", useUnmergedTree = true).performClick()
         waitForIdle()
-        assertEquals("2", navigateToNoteId)
+        assertEquals("48", navigateToNoteId)
     }
 
     @Composable
@@ -231,7 +231,8 @@ class NotesScreenTest : NotyScreenTest() {
                 id = it.toString(),
                 title = "$title $it",
                 note = "$note $it",
-                created = currentTime - it.toLong()
+                created = currentTime - it.toLong(),
+                isPinned = false
             )
         }
     }

--- a/noty-android/app/composeapp/src/main/java/dev/shreyaspatil/noty/composeapp/component/action/NotyActions.kt
+++ b/noty-android/app/composeapp/src/main/java/dev/shreyaspatil/noty/composeapp/component/action/NotyActions.kt
@@ -27,19 +27,25 @@ import androidx.compose.material.IconButton
 import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.unit.dp
 import dev.shreyaspatil.noty.R
 
 @Composable
 fun PinAction(isPinned: Boolean, onClick: () -> Unit) {
-    val icon = painterResource(id = if (isPinned) R.drawable.ic_pinned else R.drawable.ic_unpinned)
+    val (icon, contentDescription) = if (isPinned) {
+        R.drawable.ic_pinned to "Pinned"
+    } else {
+        R.drawable.ic_unpinned to "Not Pinned"
+    }
     IconButton(onClick = onClick) {
         Icon(
-            painter = icon,
-            contentDescription = "Pinned Note",
+            painter = painterResource(id = icon),
+            contentDescription = contentDescription,
             modifier = Modifier
                 .padding(8.dp)
+                .testTag("actionTogglePin")
         )
     }
 }

--- a/noty-android/data/local/src/main/java/dev/shreyaspatil/noty/data/local/dao/NotesDao.kt
+++ b/noty-android/data/local/src/main/java/dev/shreyaspatil/noty/data/local/dao/NotesDao.kt
@@ -41,7 +41,7 @@ interface NotesDao {
     @Query("SELECT * FROM notes WHERE noteId = :noteId")
     fun getNoteById(noteId: String): Flow<NoteEntity?>
 
-    @Query("SELECT * FROM notes ORDER BY isPinned = 1 DESC, created")
+    @Query("SELECT * FROM notes ORDER BY isPinned = 1 DESC, created DESC")
     fun getAllNotes(): Flow<List<NoteEntity>>
 
     @Insert

--- a/noty-android/data/remote/build.gradle
+++ b/noty-android/data/remote/build.gradle
@@ -46,6 +46,15 @@ android {
             }
         }
     }
+    packagingOptions {
+        exclude 'META-INF/LICENSE.txt'
+        exclude 'META-INF/LICENSE.md'
+        exclude 'META-INF/LICENSE-notice.md'
+        exclude 'META-INF/NOTICE.txt'
+        exclude 'META-INF/NOTICE'
+        exclude 'META-INF/LICENSE'
+        exclude 'META-INF/DEPENDENCIES'
+    }
     namespace 'dev.shreyaspatil.noty.data.remote'
 }
 

--- a/noty-android/dependencies.gradle
+++ b/noty-android/dependencies.gradle
@@ -58,7 +58,7 @@ ext {
     lottieComposeVersion = '6.0.0'
 
     // DI
-    daggerHiltVersion = '2.45'
+    daggerHiltVersion = '2.44.2'
     jetpackHiltVersion = "1.0.0"
 
     // Networking

--- a/noty-android/repository/src/main/java/dev/shreyaspatil/noty/repository/local/NotyLocalNoteRepository.kt
+++ b/noty-android/repository/src/main/java/dev/shreyaspatil/noty/repository/local/NotyLocalNoteRepository.kt
@@ -17,8 +17,8 @@
 package dev.shreyaspatil.noty.repository.local
 
 import dev.shreyaspatil.noty.core.model.Note
-import dev.shreyaspatil.noty.core.repository.NotyNoteRepository
 import dev.shreyaspatil.noty.core.repository.Either
+import dev.shreyaspatil.noty.core.repository.NotyNoteRepository
 import dev.shreyaspatil.noty.data.local.dao.NotesDao
 import dev.shreyaspatil.noty.data.local.entity.NoteEntity
 import kotlinx.coroutines.flow.Flow
@@ -51,11 +51,11 @@ class NotyLocalNoteRepository @Inject constructor(
         val tempNoteId = NotyNoteRepository.generateTemporaryId()
         notesDao.addNote(
             NoteEntity(
-                tempNoteId,
-                title,
-                note,
-                System.currentTimeMillis(),
-                false
+                noteId = tempNoteId,
+                title = title,
+                note = note,
+                created = System.currentTimeMillis(),
+                isPinned = false
             )
         )
         Either.success(tempNoteId)


### PR DESCRIPTION
- Fixes: #619: Displayed recently added notes first
- Fixed UI tests that were broken earlier
- Added new unit tests for verification of pin and unpin feature.